### PR TITLE
Add initial audio_reach_driver kernel module sources

### DIFF
--- a/audio_reach_driver/COPYING
+++ b/audio_reach_driver/COPYING
@@ -1,0 +1,338 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Moe Ghoul>, 1 April 1989
+  Moe Ghoul, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/audio_reach_driver/Makefile
+++ b/audio_reach_driver/Makefile
@@ -1,0 +1,27 @@
+obj-m += audio_reach_driver.o
+
+audio_reach_driver-objs := \
+    q6apm-audio-mem.o \
+    q6apm-audio-pkt.o \
+    q6apm-lpass-dummy-dais.o \
+    q6prm-audioreach-clock.o \
+    q6prm-audioreach.o \
+    qcs6490-audioreach-common.o
+ccflags-y += -I$(KERNEL_SRC)/sound/soc/qcom/qdsp6 -I$(KERNEL_SRC)/sound/soc/qcom
+
+
+all:
+	$(MAKE) -C $(KERNEL_SRC) M=$(PWD) modules
+
+modules_install:
+	    $(MAKE) -C $(KERNEL_SRC) M=$(PWD) INSTALL_MOD_PATH=$(DESTDIR) modules_install
+
+clean:
+	@if [ -n "$(KERNEL_SRC)" ]; then \
+		$(MAKE) -C $(KERNEL_SRC) M=$(shell pwd) clean; \
+	elif [ -n "$(KERNELDIR)" ]; then \
+		$(MAKE) -C $(KERNELDIR) M=$(shell pwd) clean; \
+	else \
+		rm -f *.o *.ko *.mod.c *.order *.symvers; \
+	fi
+

--- a/audio_reach_driver/q6apm-audio-mem.c
+++ b/audio_reach_driver/q6apm-audio-mem.c
@@ -1,0 +1,916 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2021, Linaro Limited
+
+#include <linux/init.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/err.h>
+#include <linux/delay.h>
+#include <linux/slab.h>
+#include <linux/mutex.h>
+#include <linux/list.h>
+#include <linux/cdev.h>
+#include <linux/device.h>
+#include <linux/dma-mapping.h>
+#include <linux/dma-buf.h>
+#include <linux/dma-heap.h>
+#include <linux/export.h>
+#include <linux/fs.h>
+#include <linux/iosys-map.h>
+#include <linux/of_device.h>
+#include <linux/of_reserved_mem.h>
+#include <linux/ioctl.h>
+#include <linux/platform_device.h>
+#include <linux/firmware/qcom/qcom_scm.h>
+#include <dt-bindings/firmware/qcom,scm.h>
+#include <sound/soc.h>
+#include "q6prm-audioreach.h"
+
+#define DRV_NAME "q6apm-audio-mem"
+
+#define AUDIO_IOCTL_MAGIC 'a'
+#define IOCTL_MAP_PHYS_ADDR _IOW(AUDIO_IOCTL_MAGIC, 97, int)
+#define IOCTL_UNMAP_PHYS_ADDR _IOW(AUDIO_IOCTL_MAGIC, 98, int)
+#define IOCTL_MAP_HYP_ASSIGN _IOW(AUDIO_IOCTL_MAGIC, 99, int)
+#define IOCTL_UNMAP_HYP_ASSIGN _IOW(AUDIO_IOCTL_MAGIC, 100, int)
+
+#define MSM_AUDIO_MEM_PROBED (1 << 0)
+
+#define MSM_AUDIO_MEM_PHYS_ADDR(alloc_data) \
+	alloc_data->table->sgl->dma_address
+
+#define MSM_AUDIO_SMMU_SID_OFFSET 32
+#define MINOR_NUMBER_COUNT 1
+#define QCOM_SMMU_SID_MASK 0xF
+
+struct msm_audio_mem_private {
+	bool smmu_enabled;
+	struct device *cb_dev;
+	u8 device_status;
+	struct list_head alloc_list;
+	struct mutex list_mutex;
+	u64 smmu_sid_bits;
+	char *driver_name;
+	/*char dev related data */
+	dev_t mem_major;
+	struct class *mem_class;
+	struct device *chardev;
+	struct cdev cdev;
+};
+
+struct msm_audio_alloc_data {
+	size_t len;
+	struct iosys_map *vmap;
+	struct dma_buf *dma_buf;
+	struct dma_buf_attachment *attach;
+	struct sg_table *table;
+	struct list_head list;
+};
+
+
+struct msm_audio_mem_fd_list_private {
+	struct mutex list_mutex;
+	/*list to store fd, phy. addr and handle data */
+	struct list_head fd_list;
+};
+
+static struct msm_audio_mem_fd_list_private msm_audio_mem_fd_list = {0,};
+static bool msm_audio_mem_fd_list_init;
+
+struct msm_audio_fd_data {
+	int fd;
+	size_t plen;
+	void *handle;
+	dma_addr_t paddr;
+	struct device *dev;
+	struct list_head list;
+	bool hyp_assign;
+};
+
+static void msm_audio_mem_add_allocation(
+	struct msm_audio_mem_private *msm_audio_mem_data,
+	struct msm_audio_alloc_data *alloc_data)
+{
+	/*
+	 * Since these APIs can be invoked by multiple
+	 * clients, there is need to make sure the list
+	 * of allocations is always protected
+	 */
+	mutex_lock(&(msm_audio_mem_data->list_mutex));
+	list_add_tail(&(alloc_data->list),
+		      &(msm_audio_mem_data->alloc_list));
+	mutex_unlock(&(msm_audio_mem_data->list_mutex));
+}
+
+static int msm_audio_mem_map_kernel(struct dma_buf *dma_buf,
+	struct msm_audio_mem_private *mem_data, struct iosys_map *iosys_vmap)
+{
+	int rc = 0;
+	struct msm_audio_alloc_data *alloc_data = NULL;
+
+	rc = dma_buf_begin_cpu_access(dma_buf, DMA_BIDIRECTIONAL);
+	if (rc) {
+		pr_err("%s: kmap dma_buf_begin_cpu_access fail\n", __func__);
+		goto exit;
+	}
+
+	rc = dma_buf_vmap(dma_buf, iosys_vmap);
+	if (rc) {
+		pr_err("%s: kernel mapping of dma_buf failed\n",
+		       __func__);
+		goto exit;
+	}
+
+	/*
+	 * TBD: remove the below section once new API
+	 * for mapping kernel virtual address is available.
+	 */
+	mutex_lock(&(mem_data->list_mutex));
+	list_for_each_entry(alloc_data, &(mem_data->alloc_list),
+			    list) {
+		if (alloc_data->dma_buf == dma_buf) {
+			alloc_data->vmap = iosys_vmap;
+			break;
+		}
+	}
+	mutex_unlock(&(mem_data->list_mutex));
+
+exit:
+	return rc;
+}
+
+static int msm_audio_dma_buf_map(struct dma_buf *dma_buf,
+				 dma_addr_t *addr, size_t *len, bool is_iova,
+				 struct msm_audio_mem_private *mem_data)
+{
+
+	struct msm_audio_alloc_data *alloc_data = NULL;
+	int rc = 0;
+	struct iosys_map *iosys_vmap = NULL;
+	struct device *cb_dev = mem_data->cb_dev;
+
+	iosys_vmap = kzalloc(sizeof(*iosys_vmap), GFP_KERNEL);
+	if (!iosys_vmap)
+		return -ENOMEM;
+	/* Data required per buffer mapping */
+	alloc_data = kzalloc(sizeof(*alloc_data), GFP_KERNEL);
+	if (!alloc_data) {
+		kfree(iosys_vmap);
+		return -ENOMEM;
+	}
+	alloc_data->dma_buf = dma_buf;
+	alloc_data->len = dma_buf->size;
+	*len = dma_buf->size;
+
+	/* Attach the dma_buf to context bank device */
+	alloc_data->attach = dma_buf_attach(alloc_data->dma_buf,
+					    cb_dev);
+	if (IS_ERR(alloc_data->attach)) {
+		rc = PTR_ERR(alloc_data->attach);
+		dev_err(cb_dev,
+			"%s: Fail to attach dma_buf to CB, rc = %d\n",
+			__func__, rc);
+		goto free_alloc_data;
+	}
+
+	/*
+	 * Get the scatter-gather list.
+	 * There is no info as this is a write buffer or
+	 * read buffer, hence the request is bi-directional
+	 * to accommodate both read and write mappings.
+	 */
+	alloc_data->table = dma_buf_map_attachment(alloc_data->attach,
+				DMA_BIDIRECTIONAL);
+	if (IS_ERR(alloc_data->table)) {
+		rc = PTR_ERR(alloc_data->table);
+		dev_err(cb_dev,
+			"%s: Fail to map attachment, rc = %d\n",
+			__func__, rc);
+		goto detach_dma_buf;
+	}
+
+	/* physical address from mapping */
+	if (!is_iova) {
+		*addr = sg_phys(alloc_data->table->sgl);
+		rc = msm_audio_mem_map_kernel((void *)dma_buf, mem_data, iosys_vmap);
+		if (rc) {
+			pr_err("%s: MEM memory mapping for AUDIO failed, err:%d\n",
+				__func__, rc);
+			rc = -ENOMEM;
+			goto detach_dma_buf;
+		}
+		alloc_data->vmap = iosys_vmap;
+	} else {
+		*addr = MSM_AUDIO_MEM_PHYS_ADDR(alloc_data);
+	}
+
+	msm_audio_mem_add_allocation(mem_data, alloc_data);
+	return rc;
+
+detach_dma_buf:
+	dma_buf_detach(alloc_data->dma_buf,
+		       alloc_data->attach);
+free_alloc_data:
+	kfree(iosys_vmap);
+	kfree(alloc_data);
+	alloc_data = NULL;
+
+	return rc;
+}
+
+static int msm_audio_dma_buf_unmap(struct dma_buf *dma_buf, struct msm_audio_mem_private *mem_data)
+{
+	int rc = 0;
+	struct msm_audio_alloc_data *alloc_data = NULL;
+	struct list_head *ptr, *next;
+	bool found = false;
+	struct device *cb_dev = mem_data->cb_dev;
+
+	/*
+	 * Though list_for_each_safe is delete safe, lock
+	 * should be explicitly acquired to avoid race condition
+	 * on adding elements to the list.
+	 */
+	mutex_lock(&(mem_data->list_mutex));
+	list_for_each_safe(ptr, next,
+			    &(mem_data->alloc_list)) {
+
+		alloc_data = list_entry(ptr, struct msm_audio_alloc_data,
+					list);
+
+		if (alloc_data->dma_buf == dma_buf) {
+			found = true;
+			dma_buf_unmap_attachment(alloc_data->attach,
+						 alloc_data->table,
+						 DMA_BIDIRECTIONAL);
+
+			dma_buf_detach(alloc_data->dma_buf,
+				       alloc_data->attach);
+
+			dma_buf_put(alloc_data->dma_buf);
+
+			list_del(&(alloc_data->list));
+			kfree(alloc_data->vmap);
+			kfree(alloc_data);
+			alloc_data = NULL;
+			break;
+		}
+	}
+	mutex_unlock(&(mem_data->list_mutex));
+
+	if (!found) {
+		dev_err(cb_dev,
+			"%s: cannot find allocation, dma_buf %pK\n",
+			__func__, dma_buf);
+		rc = -EINVAL;
+	}
+
+	return rc;
+}
+
+static int msm_audio_mem_get_phys(struct dma_buf *dma_buf,
+				  dma_addr_t *addr, size_t *len, bool is_iova,
+				  struct msm_audio_mem_private *mem_data)
+{
+	int rc = 0;
+
+	rc = msm_audio_dma_buf_map(dma_buf, addr, len, is_iova, mem_data);
+	if (rc) {
+		pr_err("%s: failed to map DMA buf, err = %d\n",
+			__func__, rc);
+		goto err;
+	}
+	if (mem_data->smmu_enabled && is_iova) {
+		/* Append the SMMU SID information to the IOVA address */
+		*addr |= mem_data->smmu_sid_bits;
+	}
+
+	pr_debug("phys=%pK, len=%zd, rc=%d\n", &(*addr), *len, rc);
+err:
+	return rc;
+}
+
+static int msm_audio_mem_unmap_kernel(struct dma_buf *dma_buf,
+		struct msm_audio_mem_private *mem_data)
+{
+	int rc = 0;
+	struct iosys_map *iosys_vmap = NULL;
+	struct msm_audio_alloc_data *alloc_data = NULL;
+	struct device *cb_dev = mem_data->cb_dev;
+
+	/*
+	 * TBD: remove the below section once new API
+	 * for unmapping kernel virtual address is available.
+	 */
+	mutex_lock(&(mem_data->list_mutex));
+	list_for_each_entry(alloc_data, &(mem_data->alloc_list),
+			    list) {
+		if (alloc_data->dma_buf == dma_buf) {
+			iosys_vmap = alloc_data->vmap;
+			break;
+		}
+	}
+	mutex_unlock(&(mem_data->list_mutex));
+
+	if (!iosys_vmap) {
+		dev_err(cb_dev,
+			"%s: cannot find allocation for dma_buf %pK\n",
+			__func__, dma_buf);
+		rc = -EINVAL;
+		goto err;
+	}
+
+	dma_buf_vunmap(dma_buf, iosys_vmap);
+
+	rc = dma_buf_end_cpu_access(dma_buf, DMA_BIDIRECTIONAL);
+	if (rc) {
+		dev_err(cb_dev, "%s: kmap dma_buf_end_cpu_access fail\n",
+			__func__);
+		goto err;
+	}
+
+err:
+	return rc;
+}
+
+static int msm_audio_mem_map_buf(struct dma_buf *dma_buf, dma_addr_t *paddr,
+				 size_t *plen, struct iosys_map *iosys_vmap,
+				 struct msm_audio_mem_private *mem_data)
+{
+	int rc = 0;
+	bool is_iova = true;
+
+	if (!dma_buf || !paddr || !plen) {
+		pr_err("%s: Invalid params\n", __func__);
+		return -EINVAL;
+	}
+
+	rc = msm_audio_mem_get_phys(dma_buf, paddr, plen, is_iova, mem_data);
+	if (rc) {
+		pr_err("%s: MEM Get Physical for AUDIO failed, rc = %d\n",
+				__func__, rc);
+		dma_buf_put(dma_buf);
+		goto err;
+	}
+
+	rc = msm_audio_mem_map_kernel(dma_buf, mem_data, iosys_vmap);
+	if (rc) {
+		pr_err("%s: MEM memory mapping for AUDIO failed, err:%d\n",
+			__func__, rc);
+		rc = -ENOMEM;
+		msm_audio_dma_buf_unmap(dma_buf, mem_data);
+		goto err;
+	}
+
+err:
+	return rc;
+}
+
+void msm_audio_fd_list_debug(void)
+{
+	struct msm_audio_fd_data *msm_audio_fd_data = NULL;
+
+	list_for_each_entry(msm_audio_fd_data,
+			&msm_audio_mem_fd_list.fd_list, list) {
+		pr_debug("%s fd %d handle %pK phy. addr %pK\n", __func__,
+			msm_audio_fd_data->fd, msm_audio_fd_data->handle,
+			(void *)msm_audio_fd_data->paddr);
+	}
+}
+
+void msm_audio_update_fd_list(struct msm_audio_fd_data *msm_audio_fd_data)
+{
+	struct msm_audio_fd_data *msm_audio_fd_data1 = NULL;
+
+	mutex_lock(&(msm_audio_mem_fd_list.list_mutex));
+	list_for_each_entry(msm_audio_fd_data1,
+			&msm_audio_mem_fd_list.fd_list, list) {
+		if (msm_audio_fd_data1->fd == msm_audio_fd_data->fd) {
+			pr_err("%s fd already present, not updating the list\n",
+				__func__);
+			mutex_unlock(&(msm_audio_mem_fd_list.list_mutex));
+			return;
+		}
+	}
+	list_add_tail(&msm_audio_fd_data->list, &msm_audio_mem_fd_list.fd_list);
+	mutex_unlock(&(msm_audio_mem_fd_list.list_mutex));
+}
+
+void msm_audio_delete_fd_entry(void *handle)
+{
+	struct msm_audio_fd_data *msm_audio_fd_data = NULL;
+	struct list_head *ptr, *next;
+
+	mutex_lock(&(msm_audio_mem_fd_list.list_mutex));
+	list_for_each_safe(ptr, next,
+			&msm_audio_mem_fd_list.fd_list) {
+		msm_audio_fd_data = list_entry(ptr, struct msm_audio_fd_data,
+					list);
+		if (msm_audio_fd_data->handle == handle) {
+			pr_debug("%s deleting handle %pK entry from list\n",
+				__func__, handle);
+			list_del(&(msm_audio_fd_data->list));
+			kfree(msm_audio_fd_data);
+			break;
+		}
+	}
+	mutex_unlock(&(msm_audio_mem_fd_list.list_mutex));
+}
+
+int msm_audio_get_phy_addr(int fd, dma_addr_t *paddr, size_t *pa_len)
+{
+	struct msm_audio_fd_data *msm_audio_fd_data = NULL;
+	int status = -EINVAL;
+
+	if (!paddr) {
+		pr_err("%s Invalid paddr param status %d\n", __func__, status);
+		return status;
+	}
+	pr_debug("%s, fd %d\n", __func__, fd);
+	mutex_lock(&(msm_audio_mem_fd_list.list_mutex));
+	list_for_each_entry(msm_audio_fd_data,
+			&msm_audio_mem_fd_list.fd_list, list) {
+		if (msm_audio_fd_data->fd == fd) {
+			*paddr = msm_audio_fd_data->paddr;
+			*pa_len = msm_audio_fd_data->plen;
+			status = 0;
+			pr_debug("%s Found fd %d paddr %pK\n",
+				__func__, fd, paddr);
+			mutex_unlock(&(msm_audio_mem_fd_list.list_mutex));
+			return status;
+		}
+	}
+	mutex_unlock(&(msm_audio_mem_fd_list.list_mutex));
+	return status;
+}
+EXPORT_SYMBOL_GPL(msm_audio_get_phy_addr);
+
+int msm_audio_set_hyp_assign(int fd, bool assign)
+{
+	struct msm_audio_fd_data *msm_audio_fd_data = NULL;
+	int status = -EINVAL;
+
+	mutex_lock(&(msm_audio_mem_fd_list.list_mutex));
+	list_for_each_entry(msm_audio_fd_data,
+			&msm_audio_mem_fd_list.fd_list, list) {
+		if (msm_audio_fd_data->fd == fd) {
+			status = 0;
+			pr_debug("%s Found fd %d\n", __func__, fd);
+			msm_audio_fd_data->hyp_assign = assign;
+			mutex_unlock(&(msm_audio_mem_fd_list.list_mutex));
+			return status;
+		}
+	}
+	mutex_unlock(&(msm_audio_mem_fd_list.list_mutex));
+	return status;
+}
+
+void msm_audio_get_handle(int fd, void **handle)
+{
+	struct msm_audio_fd_data *msm_audio_fd_data = NULL;
+
+	pr_debug("%s fd %d\n", __func__, fd);
+	mutex_lock(&(msm_audio_mem_fd_list.list_mutex));
+	list_for_each_entry(msm_audio_fd_data,
+			&msm_audio_mem_fd_list.fd_list, list) {
+		if (msm_audio_fd_data->fd == fd) {
+			*handle = (struct dma_buf *)msm_audio_fd_data->handle;
+			pr_debug("%s handle %pK\n", __func__, *handle);
+			break;
+		}
+	}
+	mutex_unlock(&(msm_audio_mem_fd_list.list_mutex));
+}
+
+/**
+ * msm_audio_mem_import-
+ *        Import MEM buffer with given file descriptor
+ *
+ * @dma_buf: dma_buf for the MEM memory
+ * @fd: file descriptor for the MEM memory
+ * @bufsz: buffer size
+ * @paddr: Physical address to be assigned with allocated region
+ * @plen: length of allocated region to be assigned
+ * @iosys_vmap: Virtual mapping vmap pointer to be assigned
+ *
+ * Returns 0 on success or error on failure
+ */
+static int msm_audio_mem_import(struct dma_buf **dma_buf, int fd,
+			size_t bufsz, dma_addr_t *paddr,
+			size_t *plen, struct iosys_map *iosys_vmap,
+			struct msm_audio_mem_private *mem_data)
+{
+	int rc = 0;
+
+	if (!(mem_data->device_status & MSM_AUDIO_MEM_PROBED)) {
+		pr_debug("%s: probe is not done, deferred\n", __func__);
+		return -EPROBE_DEFER;
+	}
+
+	if (!dma_buf || !paddr || !plen) {
+		pr_err("%s: Invalid params\n", __func__);
+		return -EINVAL;
+	}
+
+	/* bufsz should be 0 and fd shouldn't be 0 as of now */
+	*dma_buf = dma_buf_get(fd);
+	pr_debug("%s: dma_buf =%pK, fd=%d\n", __func__, *dma_buf, fd);
+	if (IS_ERR_OR_NULL((void *)(*dma_buf))) {
+		pr_err("%s: dma_buf_get failed\n", __func__);
+		return -EINVAL;
+	}
+
+	if (mem_data->smmu_enabled) {
+		rc = msm_audio_mem_map_buf(*dma_buf, paddr, plen, iosys_vmap, mem_data);
+		if (rc) {
+			pr_err("%s: failed to map MEM buf, rc = %d\n", __func__, rc);
+			goto err;
+		}
+		pr_debug("%s: mapped address = %pK, size=%zd\n", __func__,
+				iosys_vmap->vaddr, bufsz);
+	} else {
+		msm_audio_dma_buf_map(*dma_buf, paddr, plen, true, mem_data);
+	}
+	return 0;
+err:
+	dma_buf_put(*dma_buf);
+	*dma_buf = NULL;
+	return rc;
+}
+
+/**
+ * msm_audio_mem_free -
+ *        fress MEM memory for given client and handle
+ *
+ * @dma_buf: dma_buf for the MEM memory
+ *
+ * Returns 0 on success or error on failure
+ */
+static int msm_audio_mem_free(struct dma_buf *dma_buf, struct msm_audio_mem_private *mem_data)
+{
+	int ret = 0;
+
+	if (!dma_buf) {
+		pr_err("%s: dma_buf invalid\n", __func__);
+		return -EINVAL;
+	}
+
+	if (mem_data->smmu_enabled) {
+		ret = msm_audio_mem_unmap_kernel(dma_buf, mem_data);
+		if (ret)
+			return ret;
+	}
+
+	msm_audio_dma_buf_unmap(dma_buf, mem_data);
+
+	return 0;
+}
+
+static int msm_audio_hyp_unassign(struct msm_audio_fd_data *msm_audio_fd_data)
+{
+	int ret = 0;
+	u64 src_vmid_unmap_list = BIT(QCOM_SCM_VMID_LPASS) | BIT(QCOM_SCM_VMID_ADSP_HEAP);
+	struct qcom_scm_vmperm dst_vmids_unmap[] = {{QCOM_SCM_VMID_HLOS, QCOM_SCM_PERM_RWX}};
+
+	if (msm_audio_fd_data->hyp_assign) {
+		ret = qcom_scm_assign_mem(msm_audio_fd_data->paddr, msm_audio_fd_data->plen,
+				&src_vmid_unmap_list, dst_vmids_unmap, ARRAY_SIZE(dst_vmids_unmap));
+		if (ret < 0) {
+			pr_err("%s: qcom assign unmap failed result = %d addr = 0x%llx size = %zu\n",
+				__func__, ret, msm_audio_fd_data->paddr, msm_audio_fd_data->plen);
+		}
+		msm_audio_fd_data->hyp_assign = false;
+		pr_debug("%s: qcom scm unmap success\n", __func__);
+	}
+	return ret;
+}
+
+/**
+ * msm_audio_mem_crash_handler -
+ *        handles cleanup after userspace crashes.
+ *
+ * To be called from machine driver.
+ */
+void msm_audio_mem_crash_handler(void)
+{
+	struct msm_audio_fd_data *msm_audio_fd_data = NULL;
+	struct list_head *ptr, *next;
+	void *handle = NULL;
+	struct msm_audio_mem_private *mem_data = NULL;
+
+	mutex_lock(&(msm_audio_mem_fd_list.list_mutex));
+	list_for_each_entry(msm_audio_fd_data,
+		&msm_audio_mem_fd_list.fd_list, list) {
+		handle = msm_audio_fd_data->handle;
+		mem_data = dev_get_drvdata(msm_audio_fd_data->dev);
+		/*  clean if CMA was used*/
+		if (msm_audio_fd_data->hyp_assign)
+			msm_audio_hyp_unassign(msm_audio_fd_data);
+		if (handle)
+			msm_audio_mem_free(handle, mem_data);
+	}
+	list_for_each_safe(ptr, next,
+		&msm_audio_mem_fd_list.fd_list) {
+		msm_audio_fd_data = list_entry(ptr, struct msm_audio_fd_data,
+						list);
+		list_del(&(msm_audio_fd_data->list));
+		kfree(msm_audio_fd_data);
+	}
+	mutex_unlock(&(msm_audio_mem_fd_list.list_mutex));
+}
+EXPORT_SYMBOL_GPL(msm_audio_mem_crash_handler);
+
+static int msm_audio_mem_open(struct inode *inode, struct file *file)
+{
+	struct msm_audio_mem_private *mem_data = container_of(inode->i_cdev,
+						struct msm_audio_mem_private,
+						cdev);
+	struct device *dev = mem_data->chardev;
+
+	get_device(dev);
+	return 0;
+}
+
+static int msm_audio_mem_release(struct inode *inode, struct file *file)
+{
+	struct msm_audio_mem_private *mem_data = container_of(inode->i_cdev,
+						struct msm_audio_mem_private,
+						cdev);
+	struct device *dev = mem_data->chardev;
+
+	put_device(dev);
+	return 0;
+}
+
+static long msm_audio_mem_ioctl(struct file *file, unsigned int ioctl_num,
+				unsigned long __user ioctl_param)
+{
+	void *mem_handle;
+	dma_addr_t paddr;
+	size_t pa_len = 0;
+	struct iosys_map *iosys_vmap = NULL;
+	int ret = 0;
+	struct msm_audio_fd_data *msm_audio_fd_data = NULL;
+	struct msm_audio_mem_private *mem_data =
+			container_of(file->f_inode->i_cdev, struct msm_audio_mem_private, cdev);
+	u64 src_vmid_map_list = BIT(QCOM_SCM_VMID_HLOS);
+	struct qcom_scm_vmperm dst_vmids_map[] = {{QCOM_SCM_VMID_LPASS, QCOM_SCM_PERM_RW},
+						 {QCOM_SCM_VMID_ADSP_HEAP, QCOM_SCM_PERM_RW}};
+	u64 src_vmid_unmap_list = BIT(QCOM_SCM_VMID_LPASS) | BIT(QCOM_SCM_VMID_ADSP_HEAP);
+	struct qcom_scm_vmperm dst_vmids_unmap[] = {{QCOM_SCM_VMID_HLOS,
+					QCOM_SCM_PERM_RWX}};
+
+	switch (ioctl_num) {
+	case IOCTL_MAP_PHYS_ADDR:
+		iosys_vmap = kzalloc(sizeof(struct msm_audio_fd_data), GFP_KERNEL);
+		if (!iosys_vmap)
+			return -ENOMEM;
+		msm_audio_fd_data = kzalloc((sizeof(struct msm_audio_fd_data)),
+					GFP_KERNEL);
+		if (!msm_audio_fd_data) {
+			kfree(iosys_vmap);
+			return -ENOMEM;
+		}
+		ret = msm_audio_mem_import((struct dma_buf **)&mem_handle, (int)ioctl_param,
+					0, &paddr, &pa_len, iosys_vmap, mem_data);
+		if (ret < 0) {
+			pr_err("%s Memory map Failed %d\n", __func__, ret);
+			kfree(iosys_vmap);
+			kfree(msm_audio_fd_data);
+			return ret;
+		}
+		msm_audio_fd_data->fd = (int)ioctl_param;
+		msm_audio_fd_data->handle = mem_handle;
+		msm_audio_fd_data->paddr = paddr;
+		msm_audio_fd_data->plen = pa_len;
+		msm_audio_fd_data->dev = mem_data->cb_dev;
+		msm_audio_update_fd_list(msm_audio_fd_data);
+		break;
+	case IOCTL_UNMAP_PHYS_ADDR:
+		msm_audio_get_handle((int)ioctl_param, &mem_handle);
+		ret = msm_audio_mem_free(mem_handle, mem_data);
+		if (ret < 0) {
+			pr_err("%s Ion free failed %d\n", __func__, ret);
+			return ret;
+		}
+		msm_audio_delete_fd_entry(mem_handle);
+		break;
+	case IOCTL_MAP_HYP_ASSIGN:
+		ret = msm_audio_get_phy_addr((int)ioctl_param, &paddr, &pa_len);
+		if (ret < 0) {
+			pr_err("%s get phys addr failed %d\n", __func__, ret);
+			return ret;
+		}
+		ret = qcom_scm_assign_mem(paddr, pa_len, &src_vmid_map_list,
+			dst_vmids_map, ARRAY_SIZE(dst_vmids_map));
+		if (ret < 0) {
+			pr_err("%s: qcom_assign failed result = %d addr = 0x%llx size = %lu\n",
+					__func__, ret, paddr, pa_len);
+			return ret;
+		}
+		pr_debug("%s: qcom scm assign success\n", __func__);
+		msm_audio_set_hyp_assign((int)ioctl_param, true);
+		break;
+	case IOCTL_UNMAP_HYP_ASSIGN:
+		ret = msm_audio_get_phy_addr((int)ioctl_param, &paddr, &pa_len);
+		if (ret < 0) {
+			pr_err("%s get phys addr failed %d\n", __func__, ret);
+			return ret;
+		}
+		ret = qcom_scm_assign_mem(paddr, pa_len, &src_vmid_unmap_list,
+			dst_vmids_unmap, ARRAY_SIZE(dst_vmids_unmap));
+		if (ret < 0) {
+			pr_err("%s: qcom scm unassign failed result = %d addr = 0x%llx size = %lu\n",
+					__func__, ret, paddr, pa_len);
+			return ret;
+		}
+		pr_debug("%s: qcom scm unassign success\n", __func__);
+		msm_audio_set_hyp_assign((int)ioctl_param, false);
+		break;
+	default:
+		pr_err_ratelimited("%s Entered default. Invalid ioctl num %u\n",
+				   __func__, ioctl_num);
+		ret = -EINVAL;
+		break;
+	}
+	return ret;
+}
+
+
+static const struct snd_soc_component_driver q6apm_audio_mem_component = {
+	.name		= DRV_NAME,
+};
+
+
+static const struct file_operations msm_audio_mem_fops = {
+	.owner = THIS_MODULE,
+	.open = msm_audio_mem_open,
+	.release = msm_audio_mem_release,
+	.unlocked_ioctl = msm_audio_mem_ioctl,
+};
+
+static int msm_audio_mem_reg_chrdev(struct msm_audio_mem_private *mem_data)
+{
+	int ret = 0;
+
+	ret = alloc_chrdev_region(&mem_data->mem_major, 0,
+				MINOR_NUMBER_COUNT, mem_data->driver_name);
+	if (ret < 0) {
+		pr_err("%s alloc_chr_dev_region failed ret : %d\n",
+			__func__, ret);
+		return ret;
+	}
+	pr_debug("%s major number %d\n", __func__, MAJOR(mem_data->mem_major));
+	mem_data->mem_class = class_create(mem_data->driver_name);
+	if (IS_ERR(mem_data->mem_class)) {
+		ret = PTR_ERR(mem_data->mem_class);
+		pr_err("%s class create failed. ret : %d\n", __func__, ret);
+		goto err_class;
+	}
+	mem_data->chardev = device_create(mem_data->mem_class, NULL,
+				mem_data->mem_major, NULL,
+				mem_data->driver_name);
+	if (IS_ERR(mem_data->chardev)) {
+		ret = PTR_ERR(mem_data->chardev);
+		pr_err("%s device create failed ret : %d\n", __func__, ret);
+		goto err_device;
+	}
+	cdev_init(&mem_data->cdev, &msm_audio_mem_fops);
+	ret = cdev_add(&mem_data->cdev, mem_data->mem_major, 1);
+	if (ret) {
+		pr_err("%s cdev add failed, ret : %d\n", __func__, ret);
+		goto err_cdev;
+	}
+	return ret;
+
+err_cdev:
+	device_destroy(mem_data->mem_class, mem_data->mem_major);
+err_device:
+	class_destroy(mem_data->mem_class);
+err_class:
+	unregister_chrdev_region(0, MINOR_NUMBER_COUNT);
+	return ret;
+}
+
+static int msm_audio_mem_unreg_chrdev(struct msm_audio_mem_private *mem_data)
+{
+	cdev_del(&mem_data->cdev);
+	device_destroy(mem_data->mem_class, mem_data->mem_major);
+	class_destroy(mem_data->mem_class);
+	unregister_chrdev_region(0, MINOR_NUMBER_COUNT);
+	return 0;
+}
+
+static int q6apm_audio_mem_probe(struct platform_device *pdev)
+{
+	int rc = 0;
+	u64 smmu_sid = 0;
+	u64 smmu_sid_mask = 0;
+	struct device *dev = &pdev->dev;
+	struct of_phandle_args iommuspec;
+	bool smmu_enabled = true;
+	const char *msm_audio_mem_dt = "qcom,smmu-enabled";
+        const char *msm_audio_mem_smmu_sid_mask = "qcom,smmu-sid-mask";
+	struct msm_audio_mem_private *msm_audio_mem_data = NULL;
+
+	if (dev->of_node == NULL) {
+		dev_err(dev,
+			"%s: device tree is not found\n",
+			__func__);
+		return 0;
+	}
+
+	msm_audio_mem_data = devm_kzalloc(&pdev->dev, (sizeof(struct msm_audio_mem_private)),
+			GFP_KERNEL);
+	if (!msm_audio_mem_data)
+		return -ENOMEM;
+
+
+        msm_audio_mem_data->smmu_enabled = smmu_enabled;
+
+        dev_err(dev, "%s: SMMU is %s\n", __func__, (!smmu_enabled) ? "Disabled" : "Enabled");
+
+	msm_audio_mem_data->smmu_enabled = smmu_enabled;
+
+	dev->dma_coherent = true;
+	if (smmu_enabled) {
+		msm_audio_mem_data->driver_name = "msm_audio_mem";
+		/* Get SMMU SID information from Devicetree */
+		smmu_sid_mask = QCOM_SMMU_SID_MASK;
+
+		rc = of_parse_phandle_with_args(dev->of_node, "iommus",
+						"#iommu-cells", 0, &iommuspec);
+		if (rc) {
+			dev_err(dev, "%s: could not get smmu SID, ret = %d\n",
+				__func__, rc);
+		} else {
+			smmu_sid = (iommuspec.args[0] & smmu_sid_mask);
+		}
+		msm_audio_mem_data->smmu_sid_bits =
+			smmu_sid << MSM_AUDIO_SMMU_SID_OFFSET;
+	}
+
+	if (!rc) {
+		pr_err("DEBUG:%s:%d:Probed \n",__func__,__LINE__);
+		msm_audio_mem_data->device_status |= MSM_AUDIO_MEM_PROBED;
+	}
+	msm_audio_mem_data->cb_dev = dev;
+	dev_set_drvdata(dev, msm_audio_mem_data);
+	if (!msm_audio_mem_fd_list_init) {
+		INIT_LIST_HEAD(&msm_audio_mem_fd_list.fd_list);
+		mutex_init(&(msm_audio_mem_fd_list.list_mutex));
+		msm_audio_mem_fd_list_init = true;
+	}
+	INIT_LIST_HEAD(&msm_audio_mem_data->alloc_list);
+	mutex_init(&(msm_audio_mem_data->list_mutex));
+	rc = msm_audio_mem_reg_chrdev(msm_audio_mem_data);
+	if (rc) {
+		pr_err("%s register char dev failed, rc : %d\n", __func__, rc);
+		return rc;
+	}
+	
+	devm_snd_soc_register_component(dev, &q6apm_audio_mem_component, NULL, 0);
+	return 0;
+}
+
+static void q6apm_audio_mem_remove(struct platform_device *pdev)
+{
+	struct msm_audio_mem_private *mem_data = dev_get_drvdata(&pdev->dev);
+
+	mem_data->smmu_enabled = false;
+	mem_data->device_status = 0;
+	msm_audio_mem_unreg_chrdev(mem_data);
+}
+
+#ifdef CONFIG_OF
+static const struct of_device_id q6apm_audio_mem_device_id[] = {
+	{ .compatible = "qcom,q6apm-dais" },
+	{},
+};
+MODULE_DEVICE_TABLE(of, q6apm_audio_mem_device_id);
+#endif
+
+
+static struct platform_driver q6apm_audio_mem_platform_driver = {
+	.driver = {
+		.name = "q6apm-audio-mem",
+		.of_match_table = of_match_ptr(q6apm_audio_mem_device_id),
+	},
+	.probe = q6apm_audio_mem_probe,
+	.remove = q6apm_audio_mem_remove,
+};
+//module_platform_driver(q6apm_audio_mem_platform_driver);
+
+int q6apm_audio_mem_init(void)
+{
+	    return platform_driver_register(&q6apm_audio_mem_platform_driver);
+}
+
+void q6apm_audio_mem_exit(void)
+{
+	    platform_driver_unregister(&q6apm_audio_mem_platform_driver);
+}
+
+MODULE_DESCRIPTION("Q6APM audio mem driver");
+MODULE_LICENSE("GPL");
+MODULE_IMPORT_NS("DMA_BUF");

--- a/audio_reach_driver/q6apm-audio-pkt.c
+++ b/audio_reach_driver/q6apm-audio-pkt.c
@@ -1,0 +1,655 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2020, Linaro Limited
+// Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+
+#include <dt-bindings/soc/qcom,gpr.h>
+#include <linux/platform_device.h>
+#include <linux/delay.h>
+#include <linux/jiffies.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/of.h>
+#include <linux/of_platform.h>
+#include <linux/sched.h>
+#include <linux/slab.h>
+#include <linux/refcount.h>
+#include <linux/device.h>
+#include <linux/skbuff.h>
+#include <linux/cdev.h>
+#include <linux/idr.h>
+#include <linux/of.h>
+#include <linux/fs.h>
+#include <linux/uaccess.h>
+#include <linux/termios.h>
+#include <linux/soc/qcom/apr.h>
+#include <linux/wait.h>
+#include <sound/soc.h>
+#include <sound/soc-dapm.h>
+#include <sound/pcm.h>
+#include "audioreach.h"
+#include "q6apm.h"
+#include "q6prm-audioreach.h"
+
+#define APM_CMD_SHARED_MEM_MAP_REGIONS          0x0100100C
+#define APM_MEMORY_MAP_BIT_MASK_IS_OFFSET_MODE  0x00000004UL
+
+static bool audio_pkt_probed;
+/* Define Logging Macros */
+static int audio_pkt_debug_mask;
+enum {
+		AUDIO_PKT_INFO = 1U << 0,
+};
+
+#define AUDIO_PKT_INFO(x, ...)							\
+do {										\
+	if (audio_pkt_debug_mask & AUDIO_PKT_INFO) {				\
+		pr_info_ratelimited("[%s]: "x, __func__, ##__VA_ARGS__);	\
+	}									\
+} while (0)
+
+#define AUDIO_PKT_ERR(x, ...)							\
+{										\
+	pr_err_ratelimited("[%s]: "x, __func__, ##__VA_ARGS__);			\
+}
+
+#define MODULE_NAME "audio-pkt"
+#define MINOR_NUMBER_COUNT 1
+#define AUDPKT_DRIVER_NAME "aud_pasthru_adsp"
+#define CHANNEL_NAME "to_apps"
+#define APM_AUDIO_DRV_NAME "q6apm-audio-pkt"
+
+struct q6apm_audio_pkt {
+        struct device *dev;
+	gpr_port_t *port;
+        gpr_device_t *adev;
+        /* For Graph OPEN/START/STOP/CLOSE operations */
+        //wait_queue_head_t wait;
+        struct gpr_ibasic_rsp_result_t result;
+
+        struct mutex cmd_lock;
+        uint32_t state;
+
+
+	struct cdev cdev;
+	struct mutex lock;
+	spinlock_t queue_lock;
+	struct sk_buff_head queue;
+	wait_queue_head_t readq;
+	char dev_name[20];
+	char ch_name[20];
+	dev_t audio_pkt_major;
+	struct class *audio_pkt_class;
+};
+
+struct audio_pkt_apm_cmd_shared_mem_map_regions_t {
+	uint16_t mem_pool_id;
+	uint16_t num_regions;
+	uint32_t property_flag;
+
+};
+
+struct audio_pkt_apm_shared_map_region_payload_t {
+	uint32_t shm_addr_lsw;
+	uint32_t shm_addr_msw;
+	uint32_t mem_size_bytes;
+};
+
+struct audio_pkt_apm_mem_map {
+	struct audio_pkt_apm_cmd_shared_mem_map_regions_t mmap_header;
+	struct audio_pkt_apm_shared_map_region_payload_t mmap_payload;
+};
+
+struct audio_gpr_pkt {
+	struct gpr_hdr audpkt_hdr;
+	struct audio_pkt_apm_mem_map audpkt_mem_map;
+};
+
+typedef void (*audio_pkt_clnt_cb_fn)(void *buf, int len, void *priv);
+
+struct audio_pkt_clnt_ch {
+	int client_id;
+	audio_pkt_clnt_cb_fn func;
+};
+
+#define dev_to_audpkt_dev(_dev) container_of(_dev, struct q6apm_audio_pkt, dev)
+#define cdev_to_audpkt_dev(_cdev) container_of(_cdev, struct q6apm_audio_pkt, cdev)
+
+static struct q6apm_audio_pkt *g_apm;
+
+int q6apm_send_audio_cmd_sync(struct device *dev, gpr_device_t *gdev,
+			     struct gpr_ibasic_rsp_result_t *result, struct mutex *cmd_lock,
+			     gpr_port_t *port, wait_queue_head_t *cmd_wait,
+			     struct gpr_pkt *pkt, uint32_t rsp_opcode)
+{
+
+	struct gpr_hdr *hdr = &pkt->hdr;
+	int rc, wait_time = 2;
+
+	mutex_lock(cmd_lock);
+	result->opcode = 0;
+	result->status = 0;
+
+	if (hdr->opcode == APM_CMD_CLOSE_ALL)
+		wait_time = 20;
+
+	if (port)
+		rc = gpr_send_port_pkt(port, pkt);
+	else if (gdev)
+		rc = gpr_send_pkt(gdev, pkt);
+	else
+		rc = -EINVAL;
+
+	if (rc < 0)
+		goto err;
+
+	if (rsp_opcode)
+		rc = wait_event_timeout(*cmd_wait, (result->opcode == hdr->opcode) ||
+					(result->opcode == rsp_opcode),	wait_time * HZ);
+	else
+		rc = wait_event_timeout(*cmd_wait, (result->opcode == hdr->opcode), wait_time * HZ);
+
+	if (!rc) {
+		dev_err(dev, "CMD timeout for [%x] opcode\n", hdr->opcode);
+		rc = -ETIMEDOUT;
+	} else if (result->status > 0) {
+		dev_err(dev, "DSP returned error[%x] %x\n", hdr->opcode, result->status);
+		rc = -EINVAL;
+	} else {
+		/* DSP successfully finished the command */
+		rc = 0;
+	}
+
+err:
+	mutex_unlock(cmd_lock);
+	return rc;
+}
+EXPORT_SYMBOL_GPL(q6apm_send_audio_cmd_sync);
+
+
+int q6apm_audio_send_cmd(struct q6apm_audio_pkt *apm, struct gpr_pkt *pkt, uint32_t rsp_opcode)
+{
+	gpr_device_t *gdev = apm->adev;
+
+	return q6apm_send_audio_cmd_sync(&gdev->dev, gdev, &apm->result, &apm->lock,
+					NULL, &apm->readq, pkt, rsp_opcode);
+}
+EXPORT_SYMBOL_GPL(q6apm_audio_send_cmd);
+
+static void *__q6apm_audio_alloc_pkt(int payload_size, uint32_t opcode, uint32_t token,
+				    uint32_t src_port, uint32_t dest_port, bool has_cmd_hdr)
+{
+	struct gpr_pkt *pkt;
+	void *p;
+	int pkt_size = GPR_HDR_SIZE + payload_size;
+
+	if (has_cmd_hdr)
+		pkt_size += APM_CMD_HDR_SIZE;
+
+	p = kzalloc(pkt_size, GFP_KERNEL);
+	if (!p)
+		return ERR_PTR(-ENOMEM);
+
+	pkt = p;
+	pkt->hdr.version = GPR_PKT_VER;
+	pkt->hdr.hdr_size = GPR_PKT_HEADER_WORD_SIZE;
+	pkt->hdr.pkt_size = pkt_size;
+	pkt->hdr.dest_port = dest_port;
+	pkt->hdr.src_port = src_port;
+
+	pkt->hdr.dest_domain = GPR_DOMAIN_ID_ADSP;
+	pkt->hdr.src_domain = GPR_DOMAIN_ID_APPS;
+	pkt->hdr.token = token;
+	pkt->hdr.opcode = opcode;
+
+	if (has_cmd_hdr) {
+		struct apm_cmd_header *cmd_header;
+
+		p = p + GPR_HDR_SIZE;
+		cmd_header = p;
+		cmd_header->payload_size = payload_size;
+	}
+
+	return pkt;
+}
+
+void *q6apm_audio_alloc_apm_cmd_pkt(int pkt_size, uint32_t opcode, uint32_t token)
+{
+	return __q6apm_audio_alloc_pkt(pkt_size, opcode, token, GPR_APM_MODULE_IID,
+				       APM_MODULE_INSTANCE_ID, true);
+}
+EXPORT_SYMBOL_GPL(q6apm_audio_alloc_apm_cmd_pkt);
+
+static int q6apm_audio_get_apm_state(struct q6apm_audio_pkt *apm)
+{
+	struct gpr_pkt *pkt;
+
+	pkt = q6apm_audio_alloc_apm_cmd_pkt(0, APM_CMD_GET_SPF_STATE, 0);
+	if (IS_ERR(pkt))
+		return PTR_ERR(pkt);
+
+	q6apm_audio_send_cmd(apm, pkt, APM_CMD_RSP_GET_SPF_STATE);
+
+	kfree(pkt);
+
+	return apm->state;
+}
+
+bool q6apm_audio_is_adsp_ready(void)
+{
+	if (g_apm)
+		return q6apm_audio_get_apm_state(g_apm);
+
+	return false;
+}
+EXPORT_SYMBOL_GPL(q6apm_audio_is_adsp_ready);
+
+void q6apm_audio_close_all(void)
+{
+	struct gpr_pkt *pkt;
+
+	pkt = q6apm_audio_alloc_apm_cmd_pkt(0, APM_CMD_CLOSE_ALL, 0);
+	if (IS_ERR(pkt))
+		return;
+
+	q6apm_audio_send_cmd(g_apm, pkt, GPR_BASIC_RSP_RESULT);
+
+	kfree(pkt);
+}
+EXPORT_SYMBOL_GPL(q6apm_audio_close_all);
+
+int audio_pkt_open(struct inode *inode, struct file *file)
+{
+	struct q6apm_audio_pkt *audpkt_dev = cdev_to_audpkt_dev(inode->i_cdev);
+	struct device *dev = audpkt_dev->dev;
+
+	AUDIO_PKT_ERR("for %s\n", audpkt_dev->ch_name);
+
+	get_device(dev);
+	file->private_data = audpkt_dev;
+
+	return 0;
+}
+
+/**
+ * audio_pkt_release() - release operation on audio_pkt device
+ * inode:	Pointer to the inode structure.
+ * file:	Pointer to the file structure.
+ *
+ * This function is used to release the audio pkt device when
+ * userspace client do a close() system call. All input arguments are
+ * validated by the virtual file system before calling this function.
+ */
+int audio_pkt_release(struct inode *inode, struct file *file)
+{
+	struct q6apm_audio_pkt *audpkt_dev = cdev_to_audpkt_dev(inode->i_cdev);
+	struct device *dev = audpkt_dev->dev;
+	struct sk_buff *skb;
+	unsigned long flags;
+
+	spin_lock_irqsave(&audpkt_dev->queue_lock, flags);
+
+	/* Discard all SKBs */
+	while (!skb_queue_empty(&audpkt_dev->queue)) {
+		skb = skb_dequeue(&audpkt_dev->queue);
+		kfree_skb(skb);
+	}
+	wake_up_interruptible(&audpkt_dev->readq);
+	spin_unlock_irqrestore(&audpkt_dev->queue_lock, flags);
+
+	put_device(dev);
+	file->private_data = NULL;
+	q6apm_audio_close_all();
+	msm_audio_mem_crash_handler();
+
+	return 0;
+}
+
+/**
+ * audio_pkt_read() - read() syscall for the audio_pkt device
+ * file:	Pointer to the file structure.
+ * buf:		Pointer to the userspace buffer.
+ * count:	Number bytes to read from the file.
+ * ppos:	Pointer to the position into the file.
+ *
+ * This function is used to Read the data from audio pkt device when
+ * userspace client do a read() system call. All input arguments are
+ * validated by the virtual file system before calling this function.
+ */
+ssize_t audio_pkt_read(struct file *file, char __user *buf,
+		       size_t count, loff_t *ppos)
+{
+	struct q6apm_audio_pkt *audpkt_dev = file->private_data;
+	unsigned long flags;
+	struct sk_buff *skb;
+	int use;
+	uint32_t *temp;
+
+	if (!audpkt_dev) {
+		AUDIO_PKT_ERR("invalid device handle\n");
+		return -EINVAL;
+	}
+
+	spin_lock_irqsave(&audpkt_dev->queue_lock, flags);
+	/* Wait for data in the queue */
+	if (skb_queue_empty(&audpkt_dev->queue)) {
+		spin_unlock_irqrestore(&audpkt_dev->queue_lock, flags);
+
+		if (file->f_flags & O_NONBLOCK)
+			return -EAGAIN;
+
+		/* Wait until we get data or the endpoint goes away */
+		if (wait_event_interruptible(audpkt_dev->readq,
+					!skb_queue_empty(&audpkt_dev->queue)))
+			return -ERESTARTSYS;
+
+		spin_lock_irqsave(&audpkt_dev->queue_lock, flags);
+	}
+
+	skb = skb_dequeue(&audpkt_dev->queue);
+	spin_unlock_irqrestore(&audpkt_dev->queue_lock, flags);
+	if (!skb)
+		return -EFAULT;
+
+	use = min_t(size_t, count, skb->len);
+	if (copy_to_user(buf, skb->data, use))
+		use = -EFAULT;
+	temp = (uint32_t *) skb->data;
+	kfree_skb(skb);
+
+	return use;
+}
+
+/**
+ * audpkt_update_physical_addr - Update physical address
+ * audpkt_hdr:	Pointer to the file structure.
+ */
+int audpkt_chk_and_update_physical_addr(struct audio_gpr_pkt *gpr_pkt)
+{
+	size_t pa_len = 0;
+	dma_addr_t paddr = 0;
+	int ret = 0;
+
+	if (gpr_pkt->audpkt_mem_map.mmap_header.property_flag &
+				APM_MEMORY_MAP_BIT_MASK_IS_OFFSET_MODE) {
+
+		/* TODO: move physical address mapping to use DMA-BUF heaps */
+		ret = msm_audio_get_phy_addr(
+				(int) gpr_pkt->audpkt_mem_map.mmap_payload.shm_addr_lsw,
+				&paddr, &pa_len);
+		if (ret < 0) {
+			AUDIO_PKT_ERR("%s Get phy. address failed, ret %d\n",
+					__func__, ret);
+			return ret;
+		}
+
+		AUDIO_PKT_INFO("%s physical address %pK", __func__,
+				(void *) paddr);
+		gpr_pkt->audpkt_mem_map.mmap_payload.shm_addr_lsw = (uint32_t) paddr;
+		gpr_pkt->audpkt_mem_map.mmap_payload.shm_addr_msw = (uint64_t) paddr >> 32;
+	}
+	return ret;
+}
+
+/**
+ * audio_pkt_write() - write() syscall for the audio_pkt device
+ * file:	Pointer to the file structure.
+ * buf:		Pointer to the userspace buffer.
+ * count:	Number bytes to read from the file.
+ * ppos:	Pointer to the position into the file.
+ *
+ * This function is used to write the data to audio pkt device when
+ * userspace client do a write() system call. All input arguments are
+ * validated by the virtual file system before calling this function.
+ */
+ssize_t audio_pkt_write(struct file *file, const char __user *buf,
+			size_t count, loff_t *ppos)
+{
+	struct q6apm_audio_pkt *audpkt_dev = file->private_data;
+	struct gpr_hdr *audpkt_hdr = NULL;
+	void *kbuf;
+	int ret;
+
+	if (!audpkt_dev)  {
+		AUDIO_PKT_ERR("invalid device handle\n");
+		return -EINVAL;
+	}
+
+	kbuf = memdup_user(buf, count);
+	if (IS_ERR(kbuf))
+		return PTR_ERR(kbuf);
+
+	audpkt_hdr = (struct gpr_hdr *) kbuf;
+	if (audpkt_hdr->opcode == APM_CMD_SHARED_MEM_MAP_REGIONS) {
+		ret = audpkt_chk_and_update_physical_addr((struct audio_gpr_pkt *) audpkt_hdr);
+		if (ret < 0) {
+			AUDIO_PKT_ERR("Update Physical Address Failed -%d\n", ret);
+			return ret;
+		}
+	}
+
+	if (mutex_lock_interruptible(&audpkt_dev->lock)) {
+		ret = -ERESTARTSYS;
+		goto free_kbuf;
+	}
+	ret = gpr_send_pkt(audpkt_dev->adev, (struct gpr_pkt *) kbuf);
+	if (ret < 0) {
+		AUDIO_PKT_ERR("APR Send Packet Failed ret -%d\n", ret);
+		return ret;
+	}
+	mutex_unlock(&audpkt_dev->lock);
+
+free_kbuf:
+	kfree(kbuf);
+	return ret < 0 ? ret : count;
+}
+
+/**
+ * audio_pkt_poll() - poll() syscall for the audio_pkt device
+ * file:	Pointer to the file structure.
+ * wait:	pointer to Poll table.
+ *
+ * This function is used to poll on the audio pkt device when
+ * userspace client do a poll() system call. All input arguments are
+ * validated by the virtual file system before calling this function.
+ */
+static unsigned int audio_pkt_poll(struct file *file, poll_table *wait)
+{
+	struct q6apm_audio_pkt *audpkt_dev = file->private_data;
+	unsigned int mask = 0;
+	unsigned long flags;
+
+	audpkt_dev = file->private_data;
+	if (!audpkt_dev) {
+		AUDIO_PKT_ERR("invalid device handle\n");
+		return POLLERR;
+	}
+
+	poll_wait(file, &audpkt_dev->readq, wait);
+
+	mutex_lock(&audpkt_dev->lock);
+
+	spin_lock_irqsave(&audpkt_dev->queue_lock, flags);
+	if (!skb_queue_empty(&audpkt_dev->queue))
+		mask |= POLLIN | POLLRDNORM;
+
+	spin_unlock_irqrestore(&audpkt_dev->queue_lock, flags);
+
+	mutex_unlock(&audpkt_dev->lock);
+
+	return mask;
+}
+
+
+static const struct file_operations audio_pkt_fops = {
+	.owner = THIS_MODULE,
+	.open = audio_pkt_open,
+	.release = audio_pkt_release,
+	.read = audio_pkt_read,
+	.write = audio_pkt_write,
+	.poll = audio_pkt_poll,
+};
+
+static int q6apm_audio_pkt_probe(gpr_device_t *adev)
+{
+	struct device *dev = &adev->dev;
+	struct q6apm_audio_pkt *apm;
+	int ret;
+
+	apm = devm_kzalloc(dev, sizeof(*apm), GFP_KERNEL);
+	if (!apm)
+		return -ENOMEM;
+
+
+	ret = alloc_chrdev_region(&apm->audio_pkt_major, 0,
+				  MINOR_NUMBER_COUNT, AUDPKT_DRIVER_NAME);
+	if (ret < 0) {
+		pr_err("alloc_chrdev_region failed ret:%d\n", ret);
+		goto err_chrdev;
+	}
+
+	apm->audio_pkt_class = class_create(AUDPKT_DRIVER_NAME);
+	if (IS_ERR(apm->audio_pkt_class)) {
+		ret = PTR_ERR(apm->audio_pkt_class);
+		pr_err("class_create failed ret:%ld\n",
+			      PTR_ERR(apm->audio_pkt_class));
+		goto err_class;
+	}
+
+	apm->dev = device_create(apm->audio_pkt_class, NULL,
+					apm->audio_pkt_major, NULL,
+					AUDPKT_DRIVER_NAME);
+	if (IS_ERR(apm->dev)) {
+		ret = PTR_ERR(apm->dev);
+		pr_err("device_create failed ret:%ld\n",
+			      PTR_ERR(apm->dev));
+		goto err_device;
+	}
+
+	strscpy(apm->dev_name, CHANNEL_NAME, 20);
+	strscpy(apm->ch_name, CHANNEL_NAME, 20);
+	dev_set_name(apm->dev, apm->dev_name);
+
+
+	dev_set_drvdata(dev, apm);
+
+	mutex_init(&apm->lock);
+	apm->adev = adev;
+
+
+	spin_lock_init(&apm->queue_lock);
+	skb_queue_head_init(&apm->queue);
+	init_waitqueue_head(&apm->readq);
+
+	g_apm = apm;
+
+	cdev_init(&apm->cdev, &audio_pkt_fops);
+	apm->cdev.owner = THIS_MODULE;
+
+	ret = cdev_add(&apm->cdev, apm->audio_pkt_major,
+		       MINOR_NUMBER_COUNT);
+	if (ret) {
+		AUDIO_PKT_ERR("cdev_add failed for %s ret:%d\n",
+			      apm->dev_name, ret);
+		goto free_dev;
+	}
+
+	q6apm_audio_is_adsp_ready();
+	AUDIO_PKT_INFO("Audio Packet Port Driver Initialized\n");
+	return of_platform_populate(dev->of_node, NULL, NULL, dev);
+
+free_dev:
+	put_device(dev);
+	device_destroy(apm->audio_pkt_class, apm->audio_pkt_major);
+err_device:
+	class_destroy(apm->audio_pkt_class);
+err_class:
+	unregister_chrdev_region(MAJOR(apm->audio_pkt_major),
+				 MINOR_NUMBER_COUNT);
+err_chrdev:
+	return ret;
+}
+
+static int q6apm_audio_pkt_callback(struct gpr_resp_pkt *data, void *priv, int op)
+{
+	gpr_device_t *gdev = priv;
+	struct q6apm_audio_pkt *apm = dev_get_drvdata(&gdev->dev);
+	struct device *dev = &gdev->dev;
+	struct gpr_ibasic_rsp_result_t *result;
+	struct gpr_hdr *hdr = &data->hdr;
+	uint8_t *pkt = NULL;
+	uint16_t hdr_size, pkt_size;
+	unsigned long flags;
+	struct sk_buff *skb;
+
+
+        hdr_size = hdr->hdr_size * 4;
+        pkt_size = hdr->pkt_size;
+
+        pkt = kmalloc(pkt_size, GFP_KERNEL);
+        if (!pkt)
+                return -ENOMEM;
+
+        memcpy(pkt, (uint8_t *)data, hdr_size);
+        memcpy(pkt + hdr_size, (uint8_t *)data->payload, pkt_size - hdr_size);
+
+        skb = alloc_skb(pkt_size, GFP_ATOMIC);
+        if (!skb)
+                return -ENOMEM;
+
+        skb_put_data(skb, (void *)pkt, pkt_size);
+
+        kfree(pkt);
+        spin_lock_irqsave(&apm->queue_lock, flags);
+        skb_queue_tail(&apm->queue, skb);
+        spin_unlock_irqrestore(&apm->queue_lock, flags);
+
+
+	/* wake up any blocking processes, waiting for new data */
+	wake_up_interruptible(&apm->readq);
+	if(hdr->opcode == APM_CMD_RSP_GET_SPF_STATE) {
+                 //result = data->payload;
+                 //apm->result.opcode = hdr->opcode;
+                 //apm->result.status = 0;
+                 /* First word of result it state */
+                 apm->state = hdr->opcode;
+     }
+
+	return 0;
+}
+
+static void q6apm_audio_pkt_remove(gpr_device_t *adev)
+{
+	of_platform_depopulate(&adev->dev);
+}
+
+#ifdef CONFIG_OF
+static const struct of_device_id q6apm_audio_device_id[]  = {
+	{ .compatible = "qcom,q6apm" },
+	{},
+};
+MODULE_DEVICE_TABLE(of, q6apm_audio_device_id);
+#endif
+
+static gpr_driver_t apm_driver = {
+	.probe = q6apm_audio_pkt_probe,
+	.remove = q6apm_audio_pkt_remove,
+	.gpr_callback = q6apm_audio_pkt_callback,
+	.driver = {
+		.name = "qcom-apm-audio-pkt",
+		.of_match_table = of_match_ptr(q6apm_audio_device_id),
+	},
+};
+
+//module_gpr_driver(apm_driver);
+int q6apm_audio_pkt_init(void)
+{
+	    return apr_driver_register(&apm_driver);;//gpr_driver_register(&apm_driver);
+}
+
+void q6apm_audio_pkt_exit(void)
+{
+	apr_driver_unregister(&apm_driver);
+//	    gpr_driver_unregister(&apm_driver);
+}
+MODULE_DESCRIPTION("Audio Process Manager");
+MODULE_LICENSE("GPL");

--- a/audio_reach_driver/q6apm-lpass-dummy-dais.c
+++ b/audio_reach_driver/q6apm-lpass-dummy-dais.c
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2021, Linaro Limited
+// Copyright (c) 2023-2025 Qualcomm Innovation Center, Inc. All rights reserved.
+
+#include <dt-bindings/sound/qcom,q6dsp-lpass-ports.h>
+#include <linux/err.h>
+#include <linux/init.h>
+#include <linux/module.h>
+#include <linux/device.h>
+#include <linux/platform_device.h>
+#include <linux/slab.h>
+#include <sound/pcm.h>
+#include <sound/soc.h>
+#include <sound/pcm_params.h>
+#include <linux/clk.h>
+#include "q6dsp-lpass-ports.h"
+#include "q6dsp-common.h"
+#include "audioreach.h"
+#include "q6apm.h"
+#include "q6prm.h"
+#include "q6dsp-lpass-clocks.h"
+
+#define AUDIOREACH_BE_PCM_BASE	16
+
+struct q6apm_lpass_dai_data {
+	struct q6apm_graph *graph[APM_PORT_MAX];
+	bool is_port_started[APM_PORT_MAX];
+	struct audioreach_module_config module_config[APM_PORT_MAX];
+};
+
+static const struct snd_pcm_hardware q6apm_dummy_dma_hardware = {
+	.info               = SNDRV_PCM_INFO_INTERLEAVED |
+				SNDRV_PCM_INFO_BLOCK_TRANSFER,
+	.buffer_bytes_max   = 128 * 1024,
+	.period_bytes_min   = PAGE_SIZE,
+	.period_bytes_max   = PAGE_SIZE * 2,
+	.periods_min        = 2,
+	.periods_max        = 128,
+};
+
+static int q6apm_lpass_dai_dummy_startup(struct snd_pcm_substream *substream,
+					 struct snd_soc_dai *dai)
+{
+	snd_soc_set_runtime_hwparams(substream, &q6apm_dummy_dma_hardware);
+	return 0;
+}
+
+static const struct snd_soc_dai_ops q6dummy_ops = {
+	.startup	= q6apm_lpass_dai_dummy_startup,
+};
+
+static const struct snd_soc_dai_ops q6i2sdummy_ops = {
+	.startup	= q6apm_lpass_dai_dummy_startup,
+};
+
+static const struct snd_soc_dai_ops q6tdmdummy_ops = {
+	.startup	= q6apm_lpass_dai_dummy_startup,
+};
+
+static const struct snd_soc_component_driver q6apm_lpass_dummy_dai_component = {
+	.name = "q6apm-be-dummy-dai-component",
+	.of_xlate_dai_name = q6dsp_audio_ports_of_xlate_dai_name,
+	.be_pcm_base = AUDIOREACH_BE_PCM_BASE,
+	.use_dai_pcm_id = false,
+};
+
+static int q6apm_lpass_dummy_dai_dev_probe(struct platform_device *pdev)
+{
+	const struct snd_soc_component_driver *q6apm_lpass_component = NULL;
+	struct q6dsp_audio_port_dai_driver_config cfg;
+	struct q6apm_lpass_dai_data *dai_data;
+	struct snd_soc_dai_driver *dais;
+	struct device *dev = &pdev->dev;
+	int num_dais;
+
+	dai_data = devm_kzalloc(dev, sizeof(*dai_data), GFP_KERNEL);
+	if (!dai_data)
+		return -ENOMEM;
+
+	dev_set_drvdata(dev, dai_data);
+
+	memset(&cfg, 0, sizeof(cfg));
+
+	dev_info(dev, "Q6 APM DAI uses dummy ops\n");
+	cfg.q6i2s_ops = &q6i2sdummy_ops;
+	cfg.q6dma_ops = &q6dummy_ops;
+	cfg.q6hdmi_ops = &q6dummy_ops;
+	cfg.q6tdm_ops = &q6tdmdummy_ops;
+	cfg.q6slim_ops = &q6dummy_ops;
+	q6apm_lpass_component = &q6apm_lpass_dummy_dai_component;
+
+	dais = q6dsp_audio_ports_set_config(dev, &cfg, &num_dais);
+
+	return devm_snd_soc_register_component(dev, q6apm_lpass_component, dais, num_dais);
+}
+
+#ifdef CONFIG_OF
+static const struct of_device_id q6apm_lpass_dummy_dai_device_id[] = {
+	{ .compatible = "qcom,q6apm-lpass-dais" },
+	{},
+};
+MODULE_DEVICE_TABLE(of, q6apm_lpass_dummy_dai_device_id);
+#endif
+
+static struct platform_driver q6apm_lpass_dummy_dai_platform_driver = {
+	.driver = {
+		.name = "q6apm-lpass-dummy-dais",
+		.of_match_table = of_match_ptr(q6apm_lpass_dummy_dai_device_id),
+	},
+	.probe = q6apm_lpass_dummy_dai_dev_probe,
+};
+//module_platform_driver(q6apm_lpass_dummy_dai_platform_driver);
+int q6apm_lpass_dummy_dais_init(void)
+{
+	    return platform_driver_register(&q6apm_lpass_dummy_dai_platform_driver);
+}
+
+void q6apm_lpass_dummy_dais_exit(void)
+{
+	    platform_driver_unregister(&q6apm_lpass_dummy_dai_platform_driver);
+}
+
+MODULE_DESCRIPTION("AUDIOREACH APM LPASS dummy dai driver");
+MODULE_LICENSE("GPL");

--- a/audio_reach_driver/q6prm-audioreach-clock.c
+++ b/audio_reach_driver/q6prm-audioreach-clock.c
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2021, Linaro Limited
+
+#include <dt-bindings/sound/qcom,q6dsp-lpass-ports.h>
+#include <linux/err.h>
+#include <linux/init.h>
+#include <linux/clk-provider.h>
+#include <linux/module.h>
+#include <linux/device.h>
+#include <linux/platform_device.h>
+#include "q6dsp-lpass-clocks.h"
+#include "q6prm.h"
+#include "q6prm-audioreach.h"
+
+
+#define Q6PRM_CLK(id) {					\
+		.clk_id	= id,				\
+		.q6dsp_clk_id	= Q6PRM_##id,		\
+		.name = #id,				\
+		.rate = 19200000,			\
+	}
+
+static const struct q6dsp_clk_init q6prm_clks[] = {
+	Q6PRM_CLK(LPASS_CLK_ID_PRI_MI2S_IBIT),
+	Q6PRM_CLK(LPASS_CLK_ID_PRI_MI2S_EBIT),
+	Q6PRM_CLK(LPASS_CLK_ID_SEC_MI2S_IBIT),
+	Q6PRM_CLK(LPASS_CLK_ID_SEC_MI2S_EBIT),
+	Q6PRM_CLK(LPASS_CLK_ID_TER_MI2S_IBIT),
+	Q6PRM_CLK(LPASS_CLK_ID_TER_MI2S_EBIT),
+	Q6PRM_CLK(LPASS_CLK_ID_QUAD_MI2S_IBIT),
+	Q6PRM_CLK(LPASS_CLK_ID_QUAD_MI2S_EBIT),
+	Q6PRM_CLK(LPASS_CLK_ID_SPEAKER_I2S_IBIT),
+	Q6PRM_CLK(LPASS_CLK_ID_SPEAKER_I2S_EBIT),
+	Q6PRM_CLK(LPASS_CLK_ID_SPEAKER_I2S_OSR),
+	Q6PRM_CLK(LPASS_CLK_ID_QUI_MI2S_IBIT),
+	Q6PRM_CLK(LPASS_CLK_ID_QUI_MI2S_EBIT),
+	Q6PRM_CLK(LPASS_CLK_ID_SEN_MI2S_IBIT),
+	Q6PRM_CLK(LPASS_CLK_ID_SEN_MI2S_EBIT),
+	Q6PRM_CLK(LPASS_CLK_ID_INT0_MI2S_IBIT),
+	Q6PRM_CLK(LPASS_CLK_ID_INT1_MI2S_IBIT),
+	Q6PRM_CLK(LPASS_CLK_ID_INT2_MI2S_IBIT),
+	Q6PRM_CLK(LPASS_CLK_ID_INT3_MI2S_IBIT),
+	Q6PRM_CLK(LPASS_CLK_ID_INT4_MI2S_IBIT),
+	Q6PRM_CLK(LPASS_CLK_ID_INT5_MI2S_IBIT),
+	Q6PRM_CLK(LPASS_CLK_ID_INT6_MI2S_IBIT),
+	Q6PRM_CLK(LPASS_CLK_ID_QUI_MI2S_OSR),
+	Q6PRM_CLK(LPASS_CLK_ID_WSA_CORE_MCLK),
+	Q6PRM_CLK(LPASS_CLK_ID_WSA_CORE_NPL_MCLK),
+	Q6PRM_CLK(LPASS_CLK_ID_VA_CORE_MCLK),
+	Q6PRM_CLK(LPASS_CLK_ID_TX_CORE_MCLK),
+	Q6PRM_CLK(LPASS_CLK_ID_TX_CORE_NPL_MCLK),
+	Q6PRM_CLK(LPASS_CLK_ID_RX_CORE_MCLK),
+	Q6PRM_CLK(LPASS_CLK_ID_RX_CORE_NPL_MCLK),
+	Q6PRM_CLK(LPASS_CLK_ID_VA_CORE_2X_MCLK),
+	Q6PRM_CLK(LPASS_CLK_ID_WSA2_CORE_MCLK),
+	Q6PRM_CLK(LPASS_CLK_ID_WSA2_CORE_2X_MCLK),
+	Q6PRM_CLK(LPASS_CLK_ID_RX_CORE_TX_MCLK),
+	Q6PRM_CLK(LPASS_CLK_ID_RX_CORE_TX_2X_MCLK),
+	Q6PRM_CLK(LPASS_CLK_ID_WSA_CORE_TX_MCLK),
+	Q6PRM_CLK(LPASS_CLK_ID_WSA_CORE_TX_2X_MCLK),
+	Q6PRM_CLK(LPASS_CLK_ID_WSA2_CORE_TX_MCLK),
+	Q6PRM_CLK(LPASS_CLK_ID_WSA2_CORE_TX_2X_MCLK),
+	Q6PRM_CLK(LPASS_CLK_ID_RX_CORE_MCLK2_2X_MCLK),
+	Q6DSP_VOTE_CLK(LPASS_HW_MACRO_VOTE, Q6PRM_HW_CORE_ID_LPASS,
+		       "LPASS_HW_MACRO"),
+	Q6DSP_VOTE_CLK(LPASS_HW_DCODEC_VOTE, Q6PRM_HW_CORE_ID_DCODEC,
+		       "LPASS_HW_DCODEC"),
+};
+
+static const struct q6dsp_clk_desc q6dsp_clk_q6prm __maybe_unused = {
+	.clks = q6prm_clks,
+	.num_clks = ARRAY_SIZE(q6prm_clks),
+	.lpass_set_clk = q6prm_audioreach_set_lpass_clock,
+	.lpass_vote_clk = q6prm_audioreach_vote_lpass_core_hw,
+	.lpass_unvote_clk = q6prm_audioreach_unvote_lpass_core_hw,
+};
+
+#ifdef CONFIG_OF
+static const struct of_device_id q6prm_audioreach_clock_device_id[] = {
+	{ .compatible = "qcom,q6prm-lpass-clocks", .data = &q6dsp_clk_q6prm },
+	{},
+};
+MODULE_DEVICE_TABLE(of, q6prm_audioreach_clock_device_id);
+#endif
+
+static struct platform_driver q6prm_clock_platform_driver = {
+	.driver = {
+		.name = "q6prm-pass-audio-clock",
+		.of_match_table = of_match_ptr(q6prm_audioreach_clock_device_id),
+	},
+	.probe = q6dsp_clock_dev_probe,
+};
+//module_platform_driver(q6prm_clock_platform_driver);
+
+int q6prm_audioreach_clock_init(void)
+{
+	    return platform_driver_register(&q6prm_clock_platform_driver);
+}
+
+void q6prm_audioreach_clock_exit(void)
+{
+	    platform_driver_unregister(&q6prm_clock_platform_driver);
+}
+
+MODULE_DESCRIPTION("Q6 Proxy Resource Manager LPASS clock driver");
+MODULE_LICENSE("GPL");

--- a/audio_reach_driver/q6prm-audioreach.c
+++ b/audio_reach_driver/q6prm-audioreach.c
@@ -1,0 +1,357 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2021, Linaro Limited
+
+#include <linux/slab.h>
+#include <linux/wait.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/of.h>
+#include <linux/delay.h>
+#include <linux/of_platform.h>
+#include <linux/jiffies.h>
+#include <linux/soc/qcom/apr.h>
+#include <dt-bindings/soc/qcom,gpr.h>
+#include <dt-bindings/sound/qcom,q6dsp-lpass-ports.h>
+#include "q6apm.h"
+#include "q6prm.h"
+#include "audioreach.h"
+#include "q6prm-audioreach.h"
+
+struct q6prm {
+	struct device *dev;
+	gpr_device_t *gdev;
+	wait_queue_head_t wait;
+	struct gpr_ibasic_rsp_result_t result;
+	struct mutex lock;
+};
+
+#define PRM_CMD_REQUEST_HW_RSC		0x0100100F
+#define PRM_CMD_RSP_REQUEST_HW_RSC	0x02001002
+#define PRM_CMD_RELEASE_HW_RSC		0x01001010
+#define PRM_CMD_RSP_RELEASE_HW_RSC	0x02001003
+#define PARAM_ID_RSC_HW_CORE		0x08001032
+#define PARAM_ID_RSC_LPASS_CORE		0x0800102B
+#define PARAM_ID_RSC_AUDIO_HW_CLK	0x0800102C
+
+struct prm_cmd_request_hw_core {
+	struct apm_module_param_data param_data;
+	uint32_t hw_clk_id;
+} __packed;
+
+struct prm_cmd_request_rsc {
+	struct apm_module_param_data param_data;
+	uint32_t num_clk_id;
+	struct audio_hw_clk_cfg clock_id;
+} __packed;
+
+struct prm_cmd_release_rsc {
+	struct apm_module_param_data param_data;
+	uint32_t num_clk_id;
+	struct audio_hw_clk_rel_cfg clock_id;
+} __packed;
+
+int q6prm_audio_send_cmd_sync(struct device *dev, gpr_device_t *gdev,
+			     struct gpr_ibasic_rsp_result_t *result, struct mutex *cmd_lock,
+			     gpr_port_t *port, wait_queue_head_t *cmd_wait,
+			     struct gpr_pkt *pkt, uint32_t rsp_opcode)
+{
+
+	struct gpr_hdr *hdr = &pkt->hdr;
+	int rc;
+
+	mutex_lock(cmd_lock);
+	result->opcode = 0;
+	result->status = 0;
+
+	if (port)
+		rc = gpr_send_port_pkt(port, pkt);
+	else if (gdev)
+		rc = gpr_send_pkt(gdev, pkt);
+	else
+		rc = -EINVAL;
+
+	if (rc < 0)
+		goto err;
+
+	if (rsp_opcode)
+		rc = wait_event_timeout(*cmd_wait, (result->opcode == hdr->opcode) ||
+					(result->opcode == rsp_opcode),	5 * HZ);
+	else
+		rc = wait_event_timeout(*cmd_wait, (result->opcode == hdr->opcode), 5 * HZ);
+
+	if (!rc) {
+		dev_err(dev, "CMD timeout for [%x] opcode\n", hdr->opcode);
+		rc = -ETIMEDOUT;
+	} else if (result->status > 0) {
+		dev_err(dev, "DSP returned error[%x] %x\n", hdr->opcode, result->status);
+		rc = -EINVAL;
+	} else {
+		/* DSP successfully finished the command */
+		rc = 0;
+	}
+
+err:
+	mutex_unlock(cmd_lock);
+	return rc;
+}
+EXPORT_SYMBOL_GPL(q6prm_audio_send_cmd_sync);
+
+static int q6prm_audioreach_send_cmd_sync(struct q6prm *prm, struct gpr_pkt *pkt, uint32_t rsp_opcode)
+{
+	return q6prm_audio_send_cmd_sync(prm->dev, prm->gdev, &prm->result, &prm->lock,
+					NULL, &prm->wait, pkt, rsp_opcode);
+}
+
+static void *__q6prm_audioreach_alloc_pkt(int payload_size, uint32_t opcode, uint32_t token,
+				    uint32_t src_port, uint32_t dest_port, bool has_cmd_hdr)
+{
+	struct gpr_pkt *pkt;
+	void *p;
+	int pkt_size = GPR_HDR_SIZE + payload_size;
+
+	if (has_cmd_hdr)
+		pkt_size += APM_CMD_HDR_SIZE;
+
+	p = kzalloc(pkt_size, GFP_KERNEL);
+	if (!p)
+		return ERR_PTR(-ENOMEM);
+
+	pkt = p;
+	pkt->hdr.version = GPR_PKT_VER;
+	pkt->hdr.hdr_size = GPR_PKT_HEADER_WORD_SIZE;
+	pkt->hdr.pkt_size = pkt_size;
+	pkt->hdr.dest_port = dest_port;
+	pkt->hdr.src_port = src_port;
+
+	pkt->hdr.dest_domain = GPR_DOMAIN_ID_ADSP;
+	pkt->hdr.src_domain = GPR_DOMAIN_ID_APPS;
+	pkt->hdr.token = token;
+	pkt->hdr.opcode = opcode;
+
+	if (has_cmd_hdr) {
+		struct apm_cmd_header *cmd_header;
+
+		p = p + GPR_HDR_SIZE;
+		cmd_header = p;
+		cmd_header->payload_size = payload_size;
+	}
+
+	return pkt;
+}
+
+void *q6prm_audioreach_alloc_cmd_pkt(int payload_size, uint32_t opcode, uint32_t token,
+			       uint32_t src_port, uint32_t dest_port)
+{
+	return __q6prm_audioreach_alloc_pkt(payload_size, opcode, token, src_port, dest_port, true);
+}
+EXPORT_SYMBOL_GPL(q6prm_audioreach_alloc_cmd_pkt);
+
+static int q6prm_audioreach_set_hw_core_req(struct device *dev, uint32_t hw_block_id, bool enable)
+{
+	struct q6prm *prm = dev_get_drvdata(dev->parent);
+	struct apm_module_param_data *param_data;
+	struct prm_cmd_request_hw_core *req;
+	gpr_device_t *gdev = prm->gdev;
+	uint32_t opcode, rsp_opcode;
+	struct gpr_pkt *pkt;
+	int rc;
+
+	if (enable) {
+		opcode = PRM_CMD_REQUEST_HW_RSC;
+		rsp_opcode = PRM_CMD_RSP_REQUEST_HW_RSC;
+	} else {
+		opcode = PRM_CMD_RELEASE_HW_RSC;
+		rsp_opcode = PRM_CMD_RSP_RELEASE_HW_RSC;
+	}
+
+	pkt = q6prm_audioreach_alloc_cmd_pkt(sizeof(*req), opcode, 0, gdev->svc.id, GPR_PRM_MODULE_IID);
+	if (IS_ERR(pkt))
+		return PTR_ERR(pkt);
+
+	req = (void *)pkt + GPR_HDR_SIZE + APM_CMD_HDR_SIZE;
+
+	param_data = &req->param_data;
+
+	param_data->module_instance_id = GPR_PRM_MODULE_IID;
+	param_data->error_code = 0;
+	param_data->param_id = PARAM_ID_RSC_HW_CORE;
+	param_data->param_size = sizeof(*req) - APM_MODULE_PARAM_DATA_SIZE;
+
+	req->hw_clk_id = hw_block_id;
+
+	rc = q6prm_audioreach_send_cmd_sync(prm, pkt, rsp_opcode);
+
+	kfree(pkt);
+
+	return rc;
+}
+
+int q6prm_audioreach_vote_lpass_core_hw(struct device *dev, uint32_t hw_block_id,
+			     const char *client_name, uint32_t *client_handle)
+{
+	return q6prm_audioreach_set_hw_core_req(dev, hw_block_id, true);
+
+}
+EXPORT_SYMBOL_GPL(q6prm_audioreach_vote_lpass_core_hw);
+
+int q6prm_audioreach_unvote_lpass_core_hw(struct device *dev, uint32_t hw_block_id, uint32_t client_handle)
+{
+	return q6prm_audioreach_set_hw_core_req(dev, hw_block_id, false);
+}
+EXPORT_SYMBOL_GPL(q6prm_audioreach_unvote_lpass_core_hw);
+
+static int q6prm_audioreach_request_lpass_clock(struct device *dev, int clk_id, int clk_attr, int clk_root,
+				     unsigned int freq)
+{
+	struct q6prm *prm = dev_get_drvdata(dev->parent);
+	struct apm_module_param_data *param_data;
+	struct prm_cmd_request_rsc *req;
+	gpr_device_t *gdev = prm->gdev;
+	struct gpr_pkt *pkt;
+	int rc;
+
+	pkt = q6prm_audioreach_alloc_cmd_pkt(sizeof(*req), PRM_CMD_REQUEST_HW_RSC, 0, gdev->svc.id,
+				       GPR_PRM_MODULE_IID);
+	if (IS_ERR(pkt))
+		return PTR_ERR(pkt);
+
+	req = (void *)pkt + GPR_HDR_SIZE + APM_CMD_HDR_SIZE;
+
+	param_data = &req->param_data;
+
+	param_data->module_instance_id = GPR_PRM_MODULE_IID;
+	param_data->error_code = 0;
+	param_data->param_id = PARAM_ID_RSC_AUDIO_HW_CLK;
+	param_data->param_size = sizeof(*req) - APM_MODULE_PARAM_DATA_SIZE;
+
+	req->num_clk_id = 1;
+	req->clock_id.clock_id = clk_id;
+	req->clock_id.clock_freq = freq;
+	req->clock_id.clock_attri = clk_attr;
+	req->clock_id.clock_root = clk_root;
+
+	rc = q6prm_audioreach_send_cmd_sync(prm, pkt, PRM_CMD_RSP_REQUEST_HW_RSC);
+
+	kfree(pkt);
+
+	return rc;
+}
+
+static int q6prm_audioreach_release_lpass_clock(struct device *dev, int clk_id, int clk_attr, int clk_root,
+			  unsigned int freq)
+{
+	struct q6prm *prm = dev_get_drvdata(dev->parent);
+	struct apm_module_param_data *param_data;
+	struct prm_cmd_release_rsc *rel;
+	gpr_device_t *gdev = prm->gdev;
+	struct gpr_pkt *pkt;
+	int rc;
+
+	pkt = q6prm_audioreach_alloc_cmd_pkt(sizeof(*rel), PRM_CMD_RELEASE_HW_RSC, 0, gdev->svc.id,
+				       GPR_PRM_MODULE_IID);
+	if (IS_ERR(pkt))
+		return PTR_ERR(pkt);
+
+	rel = (void *)pkt + GPR_HDR_SIZE + APM_CMD_HDR_SIZE;
+
+	param_data = &rel->param_data;
+
+	param_data->module_instance_id = GPR_PRM_MODULE_IID;
+	param_data->error_code = 0;
+	param_data->param_id = PARAM_ID_RSC_AUDIO_HW_CLK;
+	param_data->param_size = sizeof(*rel) - APM_MODULE_PARAM_DATA_SIZE;
+
+	rel->num_clk_id = 1;
+	rel->clock_id.clock_id = clk_id;
+
+	rc = q6prm_audioreach_send_cmd_sync(prm, pkt, PRM_CMD_RSP_RELEASE_HW_RSC);
+
+	kfree(pkt);
+
+	return rc;
+}
+
+int q6prm_audioreach_set_lpass_clock(struct device *dev, int clk_id, int clk_attr, int clk_root,
+			  unsigned int freq)
+{
+	if (freq)
+		return q6prm_audioreach_request_lpass_clock(dev, clk_id, clk_attr, clk_root, freq);
+
+	return q6prm_audioreach_release_lpass_clock(dev, clk_id, clk_attr, clk_root, freq);
+}
+EXPORT_SYMBOL_GPL(q6prm_audioreach_set_lpass_clock);
+
+static int prm_audioreach_callback(struct gpr_resp_pkt *data, void *priv, int op)
+{
+	gpr_device_t *gdev = priv;
+	struct q6prm *prm = dev_get_drvdata(&gdev->dev);
+	struct gpr_ibasic_rsp_result_t *result;
+	struct gpr_hdr *hdr = &data->hdr;
+
+	switch (hdr->opcode) {
+	case PRM_CMD_RSP_REQUEST_HW_RSC:
+	case PRM_CMD_RSP_RELEASE_HW_RSC:
+		result = data->payload;
+		prm->result.opcode = hdr->opcode;
+		prm->result.status = result->status;
+		wake_up(&prm->wait);
+		break;
+	default:
+		break;
+	}
+
+	return 0;
+}
+
+static int prm_audioreach_probe(gpr_device_t *gdev)
+{
+	struct device *dev = &gdev->dev;
+	struct q6prm *cc;
+
+	cc = devm_kzalloc(dev, sizeof(*cc), GFP_KERNEL);
+	if (!cc)
+		return -ENOMEM;
+
+	cc->dev = dev;
+	cc->gdev = gdev;
+	mutex_init(&cc->lock);
+	init_waitqueue_head(&cc->wait);
+	dev_set_drvdata(dev, cc);
+
+	if (!q6apm_audio_is_adsp_ready()) {
+		pr_err("DEBUG:%s:%d: failed\n",__func__,__LINE__);
+		return -EPROBE_DEFER;
+	}
+
+	return devm_of_platform_populate(dev);
+}
+
+#ifdef CONFIG_OF
+static const struct of_device_id prm_audioreach_device_id[]  = {
+	{ .compatible = "qcom,q6prm" },
+	{},
+};
+MODULE_DEVICE_TABLE(of, prm_audioreach_device_id);
+#endif
+
+static gpr_driver_t prm_audioreach_driver = {
+	.probe = prm_audioreach_probe,
+	.gpr_callback = prm_audioreach_callback,
+	.driver = {
+		.name = "qcom-audioreach-prm",
+		.of_match_table = of_match_ptr(prm_audioreach_device_id),
+	},
+};
+
+//module_gpr_driver(prm_audioreach_driver);
+int q6prm_audioreach_init(void)
+{
+	    return apr_driver_register(&prm_audioreach_driver);
+}
+
+void q6prm_audioreach_exit(void)
+{
+	  apr_driver_unregister(&prm_audioreach_driver);
+}
+MODULE_DESCRIPTION("Q6 Proxy Resource Manager");
+MODULE_LICENSE("GPL");

--- a/audio_reach_driver/q6prm-audioreach.h
+++ b/audio_reach_driver/q6prm-audioreach.h
@@ -1,0 +1,38 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+
+#ifndef __Q6PRM_AUDIOREACH_H__
+#define __Q6PRM_AUDIOREACH_H__
+
+#include <linux/dma-mapping.h>
+#include "q6prm.h"
+
+int q6prm_audioreach_set_lpass_clock(struct device *dev, int clk_id, int clk_attr,
+			  int clk_root, unsigned int freq);
+int q6prm_audioreach_vote_lpass_core_hw(struct device *dev, uint32_t hw_block_id,
+			     const char *client_name, uint32_t *client_handle);
+int q6prm_audioreach_unvote_lpass_core_hw(struct device *dev, uint32_t hw_block_id,
+			       uint32_t client_handle);
+
+bool q6apm_audio_is_adsp_ready(void);
+int msm_audio_get_phy_addr(int fd, dma_addr_t *paddr, size_t *pa_len);
+void msm_audio_mem_crash_handler(void);
+
+int q6apm_audio_mem_init(void);
+void q6apm_audio_mem_exit(void);
+
+int q6apm_audio_pkt_init(void);
+void q6apm_audio_pkt_exit(void);
+
+int q6apm_lpass_dummy_dais_init(void);
+void q6apm_lpass_dummy_dais_exit(void);
+
+int q6prm_audioreach_init(void);
+void q6prm_audioreach_exit(void);
+
+int q6prm_audioreach_clock_init(void);
+void q6prm_audioreach_clock_exit(void);
+
+int snd_qcs6490_init(void);
+void snd_qcs6490_exit(void);
+
+#endif

--- a/audio_reach_driver/qcs6490-audioreach-common.c
+++ b/audio_reach_driver/qcs6490-audioreach-common.c
@@ -1,0 +1,533 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2022, Linaro Limited
+
+#include <dt-bindings/sound/qcom,q6afe.h>
+#include <linux/module.h>
+#include <linux/platform_device.h>
+#include <sound/soc.h>
+#include <sound/soc-dapm.h>
+#include <sound/pcm.h>
+#include <linux/soundwire/sdw.h>
+#include <sound/jack.h>
+#include <linux/input-event-codes.h>
+#include <sound/simple_card_utils.h>
+#include "qdsp6/q6afe.h"
+#include "sdw.h"
+#include "q6prm-audioreach.h"
+
+#define NAME_SIZE	32
+
+struct qcs6490_snd_data {
+	bool stream_prepared[AFE_PORT_MAX];
+	struct snd_soc_card *card;
+	struct sdw_stream_runtime *sruntime[AFE_PORT_MAX];
+	struct snd_soc_jack jack;
+	struct snd_soc_jack dp_jack[8];
+	bool jack_setup;
+};
+
+struct qcom_snd_dailink_data {
+	u32 mclk_fs;
+	u32 mclk_id;
+	u32 clk_direction;
+};
+
+struct qcom_snd_common_data {
+	struct qcom_snd_dailink_data *link_data;
+};
+
+static const struct snd_soc_dapm_widget qcom_jack_snd_widgets[] = {
+	SND_SOC_DAPM_HP("Headphone Jack", NULL),
+	SND_SOC_DAPM_MIC("Mic Jack", NULL),
+	SND_SOC_DAPM_SPK("DP0 Jack", NULL),
+	SND_SOC_DAPM_SPK("DP1 Jack", NULL),
+	SND_SOC_DAPM_SPK("DP2 Jack", NULL),
+	SND_SOC_DAPM_SPK("DP3 Jack", NULL),
+	SND_SOC_DAPM_SPK("DP4 Jack", NULL),
+	SND_SOC_DAPM_SPK("DP5 Jack", NULL),
+	SND_SOC_DAPM_SPK("DP6 Jack", NULL),
+	SND_SOC_DAPM_SPK("DP7 Jack", NULL),
+};
+
+
+static struct snd_soc_jack_pin qcs6490_headset_jack_pins[] = {
+	/* Headset */
+	{
+		.pin = "Mic Jack",
+		.mask = SND_JACK_MICROPHONE,
+	},
+	{
+		.pin = "Headphone Jack",
+		.mask = SND_JACK_HEADPHONE,
+	},
+};
+
+
+int qcs6490_snd_dp_jack_setup(struct snd_soc_pcm_runtime *rtd,
+			   struct snd_soc_jack *dp_jack, int dp_pcm_id)
+{
+	struct snd_soc_dai *codec_dai = snd_soc_rtd_to_codec(rtd, 0);
+	struct snd_soc_card *card = rtd->card;
+	char jack_name[NAME_SIZE];
+	int rval, i;
+
+	snprintf(jack_name, sizeof(jack_name), "DP%d Jack", dp_pcm_id);
+	rval = snd_soc_card_jack_new(card, jack_name, SND_JACK_AVOUT, dp_jack);
+	if (rval)
+		return rval;
+
+	for_each_rtd_codec_dais(rtd, i, codec_dai) {
+		rval = snd_soc_component_set_jack(codec_dai->component, dp_jack, NULL);
+		if (rval != 0 && rval != -ENOTSUPP) {
+			dev_warn(card->dev, "Failed to set jack: %d\n", rval);
+			return rval;
+		}
+	}
+
+	return 0;
+}
+
+int qcs6490_snd_wcd_jack_setup(struct snd_soc_pcm_runtime *rtd,
+			    struct snd_soc_jack *jack, bool *jack_setup)
+{
+	struct snd_soc_dai *cpu_dai = snd_soc_rtd_to_cpu(rtd, 0);
+	struct snd_soc_dai *codec_dai = snd_soc_rtd_to_codec(rtd, 0);
+	struct snd_soc_card *card = rtd->card;
+	int rval, i;
+
+	if (!*jack_setup) {
+		rval = snd_soc_card_jack_new_pins(card, "Headset Jack",
+					     SND_JACK_HEADSET | SND_JACK_LINEOUT |
+					     SND_JACK_MECHANICAL |
+					     SND_JACK_BTN_0 | SND_JACK_BTN_1 |
+					     SND_JACK_BTN_2 | SND_JACK_BTN_3 |
+					     SND_JACK_BTN_4 | SND_JACK_BTN_5,
+					     jack, qcs6490_headset_jack_pins,
+					     ARRAY_SIZE(qcs6490_headset_jack_pins));
+
+		if (rval < 0) {
+			dev_err(card->dev, "Unable to add Headphone Jack\n");
+			return rval;
+		}
+
+		snd_jack_set_key(jack->jack, SND_JACK_BTN_0, KEY_MEDIA);
+		snd_jack_set_key(jack->jack, SND_JACK_BTN_1, KEY_VOICECOMMAND);
+		snd_jack_set_key(jack->jack, SND_JACK_BTN_2, KEY_VOLUMEUP);
+		snd_jack_set_key(jack->jack, SND_JACK_BTN_3, KEY_VOLUMEDOWN);
+		*jack_setup = true;
+	}
+
+	switch (cpu_dai->id) {
+	case TX_CODEC_DMA_TX_0:
+	case TX_CODEC_DMA_TX_1:
+	case TX_CODEC_DMA_TX_2:
+	case TX_CODEC_DMA_TX_3:
+		for_each_rtd_codec_dais(rtd, i, codec_dai) {
+			rval = snd_soc_component_set_jack(codec_dai->component,
+							  jack, NULL);
+			if (rval != 0 && rval != -ENOTSUPP) {
+				dev_warn(card->dev, "Failed to set jack: %d\n", rval);
+				return rval;
+			}
+		}
+
+		break;
+	default:
+		break;
+	}
+
+
+	return 0;
+}
+
+int qcs6490_snd_parse_of(struct snd_soc_card *card)
+{
+	struct device_node *np;
+	struct device_node *codec = NULL;
+	struct device_node *platform = NULL;
+	struct device_node *cpu = NULL;
+	struct device *dev = card->dev;
+	struct snd_soc_dai_link *link;
+	struct of_phandle_args args;
+	struct snd_soc_dai_link_component *dlc;
+	int ret, num_links;
+
+	ret = snd_soc_of_parse_card_name(card, "model");
+	if (ret == 0 && !card->name)
+		/* Deprecated, only for compatibility with old device trees */
+		ret = snd_soc_of_parse_card_name(card, "qcom,model");
+	if (ret) {
+		dev_err(dev, "Error parsing card name: %d\n", ret);
+		return ret;
+	}
+
+	if (of_property_present(dev->of_node, "widgets")) {
+		ret = snd_soc_of_parse_audio_simple_widgets(card, "widgets");
+		if (ret)
+			return ret;
+	}
+
+	/* DAPM routes */
+	if (of_property_present(dev->of_node, "audio-routing")) {
+		ret = snd_soc_of_parse_audio_routing(card, "audio-routing");
+		if (ret)
+			return ret;
+	}
+	/* Deprecated, only for compatibility with old device trees */
+	if (of_property_present(dev->of_node, "qcom,audio-routing")) {
+		ret = snd_soc_of_parse_audio_routing(card, "qcom,audio-routing");
+		if (ret)
+			return ret;
+	}
+
+	ret = snd_soc_of_parse_pin_switches(card, "pin-switches");
+	if (ret)
+		return ret;
+
+	ret = snd_soc_of_parse_aux_devs(card, "aux-devs");
+	if (ret)
+		return ret;
+
+	/* Populate links */
+	num_links = of_get_available_child_count(dev->of_node);
+
+	/* Allocate the DAI link array */
+	card->dai_link = devm_kcalloc(dev, num_links, sizeof(*link), GFP_KERNEL);
+	if (!card->dai_link)
+		return -ENOMEM;
+
+	card->num_links = num_links;
+	link = card->dai_link;
+
+	for_each_available_child_of_node(dev->of_node, np) {
+		dlc = devm_kcalloc(dev, 2, sizeof(*dlc), GFP_KERNEL);
+		if (!dlc) {
+			ret = -ENOMEM;
+			goto err_put_np;
+		}
+
+		link->cpus	= &dlc[0];
+		link->platforms	= &dlc[1];
+
+		link->num_cpus		= 1;
+		link->num_platforms	= 1;
+
+		ret = of_property_read_string(np, "link-name", &link->name);
+		if (ret) {
+			dev_err(card->dev, "error getting codec dai_link name\n");
+			goto err_put_np;
+		}
+
+		cpu = of_get_child_by_name(np, "cpu");
+		codec = of_get_child_by_name(np, "codec");
+
+		if (!cpu) {
+			dev_err(dev, "%s: Can't find cpu DT node\n", link->name);
+			ret = -EINVAL;
+			goto err;
+		}
+
+		ret = snd_soc_of_get_dlc(cpu, &args, link->cpus, 0);
+		if (ret) {
+			dev_err_probe(card->dev, ret,
+				      "%s: error getting cpu dai name\n", link->name);
+			goto err;
+		}
+
+		link->id = args.args[0];	
+		link->platforms->of_node = link->cpus->of_node;
+
+		if (codec) {
+			ret = snd_soc_of_get_dai_link_codecs(dev, codec, link);
+			if (ret < 0) {
+				dev_err_probe(card->dev, ret,
+					      "%s: codec dai not found\n", link->name);
+				goto err;
+			}
+
+			if (platform) {
+				/* DPCM backend */
+				link->no_pcm = 1;
+				link->ignore_pmdown_time = 1;
+			}
+		} else {
+			/* DPCM frontend */
+			link->codecs	 = &snd_soc_dummy_dlc;
+			link->num_codecs = 1;
+			link->dynamic = 1;
+		}
+
+		if (platform || !codec) {
+			/* DPCM */
+			link->ignore_suspend = 1;
+			link->nonatomic = 1;
+		}
+
+		link->stream_name = link->name;
+		link++;
+
+		of_node_put(cpu);
+		of_node_put(codec);
+		of_node_put(platform);
+	}
+
+	if (!card->dapm_widgets) {
+		card->dapm_widgets = qcom_jack_snd_widgets;
+		card->num_dapm_widgets = ARRAY_SIZE(qcom_jack_snd_widgets);
+	}
+
+	return 0;
+err:
+	of_node_put(cpu);
+	of_node_put(codec);
+	of_node_put(platform);
+err_put_np:
+	of_node_put(np);
+	return ret;
+}
+
+static int qcs6490_snd_init(struct snd_soc_pcm_runtime *rtd)
+{
+	struct qcs6490_snd_data *data = snd_soc_card_get_drvdata(rtd->card);
+	struct snd_soc_dai *cpu_dai = snd_soc_rtd_to_cpu(rtd, 0);
+	struct snd_soc_card *card = rtd->card;
+	struct snd_soc_jack *dp_jack  = NULL;
+	int dp_pcm_id = 0;
+
+	switch (cpu_dai->id) {
+	case WSA_CODEC_DMA_RX_0:
+	case WSA_CODEC_DMA_RX_1:
+		/*
+		 * Set limit of -3 dB on Digital Volume and 0 dB on PA Volume
+		 * to reduce the risk of speaker damage until we have active
+		 * speaker protection in place.
+		 */
+		snd_soc_limit_volume(card, "WSA_RX0 Digital Volume", 81);
+		snd_soc_limit_volume(card, "WSA_RX1 Digital Volume", 81);
+		snd_soc_limit_volume(card, "SpkrLeft PA Volume", 17);
+		snd_soc_limit_volume(card, "SpkrRight PA Volume", 17);
+		break;
+	case DISPLAY_PORT_RX_0:
+		/* DISPLAY_PORT dai ids are not contiguous */
+		dp_pcm_id = 0;
+		dp_jack = &data->dp_jack[dp_pcm_id];
+		break;
+	case DISPLAY_PORT_RX_1 ... DISPLAY_PORT_RX_7:
+		dp_pcm_id = cpu_dai->id - DISPLAY_PORT_RX_1 + 1;
+		dp_jack = &data->dp_jack[dp_pcm_id];
+		break;
+	default:
+		break;
+	}
+
+	if (dp_jack)
+		return qcs6490_snd_dp_jack_setup(rtd, dp_jack, dp_pcm_id);
+
+	return qcs6490_snd_wcd_jack_setup(rtd, &data->jack, &data->jack_setup);
+}
+
+static void qcs6490_snd_shutdown(struct snd_pcm_substream *substream)
+{
+	struct snd_soc_pcm_runtime *rtd = snd_soc_substream_to_rtd(substream);
+	struct snd_soc_dai *cpu_dai = snd_soc_rtd_to_cpu(rtd, 0);
+	struct qcs6490_snd_data *pdata = snd_soc_card_get_drvdata(rtd->card);
+	struct sdw_stream_runtime *sruntime = pdata->sruntime[cpu_dai->id];
+
+	pdata->sruntime[cpu_dai->id] = NULL;
+	sdw_release_stream(sruntime);
+}
+
+static int qcs6490_be_hw_params_fixup(struct snd_soc_pcm_runtime *rtd,
+				     struct snd_pcm_hw_params *params)
+{
+	struct snd_soc_dai *cpu_dai = snd_soc_rtd_to_cpu(rtd, 0);
+	struct snd_interval *rate = hw_param_interval(params,
+					SNDRV_PCM_HW_PARAM_RATE);
+	struct snd_interval *channels = hw_param_interval(params,
+					SNDRV_PCM_HW_PARAM_CHANNELS);
+
+	rate->min = rate->max = 48000;
+	channels->min = 2;
+	channels->max = 2;
+	switch (cpu_dai->id) {
+	case TX_CODEC_DMA_TX_0:
+	case TX_CODEC_DMA_TX_1:
+	case TX_CODEC_DMA_TX_2:
+	case TX_CODEC_DMA_TX_3:
+		channels->min = 1;
+		break;
+	default:
+		break;
+	}
+
+
+	return 0;
+}
+
+static int qcs6490_snd_hw_params(struct snd_pcm_substream *substream,
+				struct snd_pcm_hw_params *params)
+{
+	struct snd_soc_pcm_runtime *rtd = snd_soc_substream_to_rtd(substream);
+	struct snd_soc_dai *cpu_dai = snd_soc_rtd_to_cpu(rtd, 0);
+	struct qcs6490_snd_data *pdata = snd_soc_card_get_drvdata(rtd->card);
+
+	return qcom_snd_sdw_hw_params(substream, params, &pdata->sruntime[cpu_dai->id]);
+}
+
+static int qcs6490_snd_prepare(struct snd_pcm_substream *substream)
+{
+	struct snd_soc_pcm_runtime *rtd = snd_soc_substream_to_rtd(substream);
+	struct snd_soc_dai *cpu_dai = snd_soc_rtd_to_cpu(rtd, 0);
+	struct qcs6490_snd_data *data = snd_soc_card_get_drvdata(rtd->card);
+	struct sdw_stream_runtime *sruntime = data->sruntime[cpu_dai->id];
+
+	return qcom_snd_sdw_prepare(substream, sruntime,
+				    &data->stream_prepared[cpu_dai->id]);
+}
+
+static int qcs6490_snd_hw_free(struct snd_pcm_substream *substream)
+{
+	struct snd_soc_pcm_runtime *rtd = snd_soc_substream_to_rtd(substream);
+	struct qcs6490_snd_data *data = snd_soc_card_get_drvdata(rtd->card);
+	struct snd_soc_dai *cpu_dai = snd_soc_rtd_to_cpu(rtd, 0);
+	struct sdw_stream_runtime *sruntime = data->sruntime[cpu_dai->id];
+
+	return qcom_snd_sdw_hw_free(substream, sruntime,
+				    &data->stream_prepared[cpu_dai->id]);
+}
+
+static const struct snd_soc_ops qcs6490_be_ops = {
+	.startup = qcom_snd_sdw_startup,
+	.shutdown = qcs6490_snd_shutdown,
+	.hw_params = qcs6490_snd_hw_params,
+	.hw_free = qcs6490_snd_hw_free,
+	.prepare = qcs6490_snd_prepare,
+};
+
+static void qcs6490_add_be_ops(struct snd_soc_card *card)
+{
+	struct snd_soc_dai_link *link;
+	int i;
+
+	for_each_card_prelinks(card, i, link) {
+		if (link->no_pcm == 1 || link->num_codecs > 0) {
+			link->init = qcs6490_snd_init;
+			link->be_hw_params_fixup = qcs6490_be_hw_params_fixup;
+			link->ops = &qcs6490_be_ops;
+		}
+	}
+}
+
+static int qcs6490_platform_probe(struct platform_device *pdev)
+{
+	struct snd_soc_card *card;
+	struct qcs6490_snd_data *data;
+	struct device *dev = &pdev->dev;
+	int ret;
+
+	card = devm_kzalloc(dev, sizeof(*card), GFP_KERNEL);
+	if (!card)
+		return -ENOMEM;
+	card->owner = THIS_MODULE;
+	/* Allocate the private data */
+	data = devm_kzalloc(dev, sizeof(*data), GFP_KERNEL);
+	if (!data)
+		return -ENOMEM;
+
+	card->dev = dev;
+	dev_set_drvdata(dev, card);
+	snd_soc_card_set_drvdata(card, data);
+	ret = qcs6490_snd_parse_of(card);
+	if (ret)
+		return ret;
+
+	card->driver_name = of_device_get_match_data(dev);
+	qcs6490_add_be_ops(card);
+	return devm_snd_soc_register_card(dev, card);
+}
+
+static const struct of_device_id snd_qcs6490_dt_match[] = {
+	{.compatible = "qcom,qcm6490-idp-sndcard", "qcm6490"},
+	{.compatible = "qcom,qcs6490-rb3gen2-sndcard", "qcs6490"},
+	{.compatible = "qcom,qcs9075-sndcard", "qcs9075"},
+	{}
+};
+
+MODULE_DEVICE_TABLE(of, snd_qcs6490_dt_match);
+
+static struct platform_driver snd_qcs6490_driver = {
+	.probe  = qcs6490_platform_probe,
+	.driver = {
+		.name = "snd-qcs6490",
+		.of_match_table = snd_qcs6490_dt_match,
+	},
+};
+int snd_qcs6490_init(void)
+{
+	    return platform_driver_register(&snd_qcs6490_driver);
+}
+
+void snd_qcs6490_exit(void)
+{
+	    platform_driver_unregister(&snd_qcs6490_driver);
+}
+static int __init audio_reach_driver_init(void)
+{
+    int ret;
+
+    ret = q6apm_audio_mem_init();
+    if (ret)
+        return ret;
+
+    ret = q6apm_audio_pkt_init();
+    if (ret)
+        goto err_mem;
+
+    ret = q6apm_lpass_dummy_dais_init();
+    if (ret)
+        goto err_pkt;
+
+    ret = q6prm_audioreach_init();
+    if (ret)
+        goto err_dais;
+
+    ret = q6prm_audioreach_clock_init();
+    if (ret)
+        goto err_audioreach;
+
+    ret = snd_qcs6490_init();
+    if (ret)
+        goto err_clock;
+
+    return 0;
+
+err_clock:
+    q6prm_audioreach_clock_exit();
+err_audioreach:
+    q6prm_audioreach_exit();
+err_dais:
+    q6apm_lpass_dummy_dais_exit();
+err_pkt:
+    q6apm_audio_pkt_exit();
+err_mem:
+    q6apm_audio_mem_exit();
+    return ret;
+}
+
+static void __exit audio_reach_driver_exit(void)
+{
+    snd_qcs6490_exit();
+    q6prm_audioreach_clock_exit();
+    q6prm_audioreach_exit();
+    q6apm_lpass_dummy_dais_exit();
+    q6apm_audio_pkt_exit();
+    q6apm_audio_mem_exit();
+}
+
+module_init(audio_reach_driver_init);
+module_exit(audio_reach_driver_exit);
+
+
+//module_platform_driver(snd_qcs6490_driver);
+MODULE_DESCRIPTION("QCS6490 ASoC Machine Driver");
+MODULE_LICENSE("GPL");


### PR DESCRIPTION
This pull request adds the AudioReach driver sources to the repository to enable integration with the meta-qcom Yocto build. The intention is to make the driver available for fetching directly from this GitHub repository as part of the build process.

Changes include:

Addition of AudioReach driver sources