### PR TITLE
audioreach: Add support for QCS8275 and QCS9100 sound cards

### DIFF
--- a/audioreach-driver/audioreach_common.c
+++ b/audioreach-driver/audioreach_common.c
@@ -511,7 +511,9 @@ static int qcs6490_platform_probe(struct platform_device *pdev)
 static const struct of_device_id snd_qcs6490_dt_match[] = {
 	{.compatible = "qcom,qcm6490-idp-sndcard", "qcm6490"},
 	{.compatible = "qcom,qcs6490-rb3gen2-sndcard", "qcs6490"},
+	{.compatible = "qcom,qcs8275-sndcard", "qcs8275"},
 	{.compatible = "qcom,qcs9075-sndcard", "qcs9075"},
+	{.compatible = "qcom,qcs9100-sndcard", "qcs9100"},
 	{}
 };
 


### PR DESCRIPTION
Extend the device tree match table in audioreach_common.c to include compatible entries for QCS8275 and QCS9100 platforms. This enables proper sound card registration for these targets during platform probe.