### PR TITLE
refactor: Makefile: add KERNEL_SRC and M to build subdir modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,13 @@
-#Top-level Makefile for AudioReach kernel modules
-
+# A list of subdirectories containing Kbuild Makefiles
 SUBDIRS := audioreach-driver
 
-.PHONY: all clean modules_install
+# Define common targets using the special automatic variable $@
+all modules clean modules_install:
+	for dir in $(SUBDIRS); do \
+        echo "Executing '$@' in $$dir..."; \
+        $(MAKE) -C $(KERNEL_SRC) M=$(CURDIR)/$$dir $@; \
+    done
 
-all:
-	@for dir in $(SUBDIRS); do \
-		$(MAKE) -C $$dir all; \
-	done
-
-modules_install:
-	@for dir in $(SUBDIRS); do \
-		$(MAKE) -C $$dir modules_install; \
-	done
-
-clean:
-	@for dir in $(SUBDIRS); do \
-		$(MAKE) -C $$dir clean; \
-	done
+# The 'modules' target is the default one, so when you run 'make'
+# it will build the modules.
+.PHONY: all modules clean modules_install

--- a/audioreach-driver/Makefile
+++ b/audioreach-driver/Makefile
@@ -7,21 +7,5 @@ audioreach_driver-objs := \
     q6prm_audioreach_clock.o \
     q6prm_audioreach.o \
     audioreach_common.o
+
 ccflags-y += -I$(KERNEL_SRC)/sound/soc/qcom/qdsp6 -I$(KERNEL_SRC)/sound/soc/qcom
-
-
-all:
-	$(MAKE) -C $(KERNEL_SRC) M=$(PWD) modules
-
-modules_install:
-	    $(MAKE) -C $(KERNEL_SRC) M=$(PWD) INSTALL_MOD_PATH=$(DESTDIR) modules_install
-
-clean:
-	@if [ -n "$(KERNEL_SRC)" ]; then \
-		$(MAKE) -C $(KERNEL_SRC) M=$(shell pwd) clean; \
-	elif [ -n "$(KERNELDIR)" ]; then \
-		$(MAKE) -C $(KERNELDIR) M=$(shell pwd) clean; \
-	else \
-		rm -f *.o *.ko *.mod.c *.order *.symvers; \
-	fi
-


### PR DESCRIPTION
Use kernel build system directly by passing KERNEL_SRC and M variables from the top-level Makefile. This ensures consistent build behavior and proper error propagation across subdirectory module builds.