### PR TITLE
audioreach-driver: add msm_audio.h support for audio memory ops

### DIFF
--- a/audioreach-driver/Makefile
+++ b/audioreach-driver/Makefile
@@ -8,4 +8,4 @@ audioreach_driver-objs := \
     q6prm_audioreach.o \
     audioreach_common.o
 
-ccflags-y += -I$(KERNEL_SRC)/sound/soc/qcom/qdsp6 -I$(KERNEL_SRC)/sound/soc/qcom
+ccflags-y += -I$(KERNEL_SRC)/sound/soc/qcom/qdsp6 -I$(KERNEL_SRC)/sound/soc/qcom -I$(src)/../include/uapi

--- a/audioreach-driver/q6apm_audio_mem.c
+++ b/audioreach-driver/q6apm_audio_mem.c
@@ -26,14 +26,9 @@
 #include <dt-bindings/firmware/qcom,scm.h>
 #include <sound/soc.h>
 #include "q6prm_audioreach.h"
+#include <linux/msm_audio.h>
 
 #define DRV_NAME "q6apm-audio-mem"
-
-#define AUDIO_IOCTL_MAGIC 'a'
-#define IOCTL_MAP_PHYS_ADDR _IOW(AUDIO_IOCTL_MAGIC, 97, int)
-#define IOCTL_UNMAP_PHYS_ADDR _IOW(AUDIO_IOCTL_MAGIC, 98, int)
-#define IOCTL_MAP_HYP_ASSIGN _IOW(AUDIO_IOCTL_MAGIC, 99, int)
-#define IOCTL_UNMAP_HYP_ASSIGN _IOW(AUDIO_IOCTL_MAGIC, 100, int)
 
 #define MSM_AUDIO_MEM_PROBED (1 << 0)
 


### PR DESCRIPTION
Update Makefile to include uapi header path for msm_audio.h. Include <linux/msm_audio.h> in q6apm_audio_mem.c to enable standardized audio IOCTLs. Commented out legacy IOCTL macros now covered by msm_audio.h.

Changes Made:
Makefile:  Updated ccflags-y to include the uapi header path for msm_audio.h.
q6apm_audio_mem.c: 
Included <linux/msm_audio.h> for standardized audio IOCTLs.
Commented out legacy IOCTL macros that are now covered by msm_audio.h.