### PR TITLE
ci: align stale workflow settings

### DIFF
--- a/.github/workflows/stale-issues.yaml
+++ b/.github/workflows/stale-issues.yaml
@@ -1,0 +1,20 @@
+name: 'Close stale issues and pull requests with no recent activity'
+on:
+  schedule:
+  - cron: "30 1 * * *"
+permissions:
+  issues: write
+  pull-requests: write
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v10
+      with:
+        stale-issue-message: 'AudioReach/audioreach.triage This issue has been marked as stale due to 30 days of inactivity.'
+        stale-pr-message: 'AudioReach/audioreach.triage This pull request has been marked as stale due to 30 days of inactivity.'
+        days-before-stale: 30
+        days-before-close: -1
+        remove-stale-when-updated: true
+        remove-issue-stale-when-updated: true
+        remove-pr-stale-when-updated: true

--- a/.github/workflows/stale-issues.yaml
+++ b/.github/workflows/stale-issues.yaml
@@ -1,0 +1,19 @@
+name: 'Close stale issues and pull requests with no recent activity'
+on:
+  schedule:
+  - cron: "30 1 * * *"
+permissions:
+  issues: write
+  pull-requests: write
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v10
+      with:
+        stale-issue-message: 'AudioReach/audioreach.triage This issue has been marked as stale due to 30 days of inactivity.'
+        stale-pr-message: 'AudioReach/audioreach.triage This pull request has been marked as stale due to 30 days of inactivity.'
+        days-before-stale: 30
+        days-before-close: -1
+        remove-issue-stale-when-updated: true
+        remove-pr-stale-when-updated: true


### PR DESCRIPTION
## Summary

- This update brings the stale-issues GitHub workflow into alignment with recommended settings.
- The changes improve the handling of stale issues and pull requests, ensure maintainers are notified when items become stale, and prevent premature closure of open work. 
- These updates help maintain consistent triage behavior across Qualcomm-hosted open-source projects.

### Changes included:

- Set a 30-day threshold for marking issues and PRs as stale. 
- Notify the appropriate team when an item becomes stale. 
- Prevent automatic closure of stale issues and PRs. 
- Improve consistency with Qualcomm open-source automation templates. 

These changes enhance project hygiene and ensure the workflow follows Qualcomm’s open-source best practices.