### PR TITLE
audioreach-driver: Guard MODULE_IMPORT_NS(DMA_BUF) for kernel < 6.13

### DIFF
--- a/audioreach-driver/ar_kcompat.h
+++ b/audioreach-driver/ar_kcompat.h
@@ -67,4 +67,19 @@
 	static int name(struct gpr_resp_pkt *data, void *priv, int op)
 #endif
 
+
+/*
+ * MODULE_IMPORT_NS syntax changed in kernel 6.13:
+ *   - < 6.13 : MODULE_IMPORT_NS(DMA_BUF)    (unquoted token)
+ *   - >= 6.13: MODULE_IMPORT_NS("DMA_BUF")  (quoted string)
+ *
+ * AR_MODULE_IMPORT_NS wraps this difference so the driver builds
+ * correctly on both old and new kernels.
+ */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0)
+# define AR_MODULE_IMPORT_NS(ns)	MODULE_IMPORT_NS(#ns)
+#else
+# define AR_MODULE_IMPORT_NS(ns)	MODULE_IMPORT_NS(ns)
+#endif
+
 #endif /* __AR_KCOMPAT_H__ */

--- a/audioreach-driver/q6apm_audio_mem.c
+++ b/audioreach-driver/q6apm_audio_mem.c
@@ -2,6 +2,7 @@
 // Copyright (c) 2021, Linaro Limited
 // Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 
+#include "ar_kcompat.h"
 #include <linux/init.h>
 #include <linux/kernel.h>
 #include <linux/module.h>
@@ -928,4 +929,4 @@ void q6apm_audio_mem_exit(void)
 
 MODULE_DESCRIPTION("Q6APM audio mem driver");
 MODULE_LICENSE("GPL");
-MODULE_IMPORT_NS("DMA_BUF");
+AR_MODULE_IMPORT_NS(DMA_BUF);


### PR DESCRIPTION
The MODULE_IMPORT_NS macro changed its argument syntax in kernel 6.13. Before 6.13 it takes an unquoted token (MODULE_IMPORT_NS(DMA_BUF)); from 6.13 onwards it requires a quoted string
(MODULE_IMPORT_NS("DMA_BUF")). Building audioreach_driver against a pre-6.13 kernel with the quoted form causes a modpost failure because the namespace import is not recognised, and the build rejects the module.

Add AR_MODULE_IMPORT_NS to ar_kcompat.h, selecting the correct form at compile time via LINUX_VERSION_CODE. Replace the bare MODULE_IMPORT_NS("DMA_BUF") in q6apm_audio_mem.c, with AR_MODULE_IMPORT_NS(DMA_BUF).

Kernel change reference:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=cdd30ebb1b9f36159d66f088b61aee264e649d7a