### PR TITLE
audioreach-driver: use dev_set_dma_coherent() in q6apm probe

### DIFF
--- a/audioreach-driver/ar_kcompat.h
+++ b/audioreach-driver/ar_kcompat.h
@@ -82,4 +82,17 @@
 # define AR_MODULE_IMPORT_NS(ns)	MODULE_IMPORT_NS(ns)
 #endif
 
+/* dev->dma_coherent direct field access changed in newer kernels. */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0)
+# define AR_HAVE_DEV_SET_DMA_COHERENT 1
+#else
+# define AR_HAVE_DEV_SET_DMA_COHERENT 0
+#endif
+
+#if AR_HAVE_DEV_SET_DMA_COHERENT
+# define AR_SET_DMA_COHERENT(dev) dev_set_dma_coherent(dev)
+#else
+# define AR_SET_DMA_COHERENT(dev) ((dev)->dma_coherent = true)
+#endif
+
 #endif /* __AR_KCOMPAT_H__ */

--- a/audioreach-driver/q6apm_audio_mem.c
+++ b/audioreach-driver/q6apm_audio_mem.c
@@ -835,7 +835,7 @@ static int q6apm_audio_mem_probe(struct platform_device *pdev)
 	dev_info(dev, "%s: SMMU is %s\n", __func__,
 		 (!msm_audio_mem_data->smmu_enabled) ? "Disabled" : "Enabled");
 
-	dev->dma_coherent = true;
+	AR_SET_DMA_COHERENT(dev);
 	if (msm_audio_mem_data->smmu_enabled) {
 		/* Get SMMU SID information from Devicetree */
 		smmu_sid_mask = QCOM_SMMU_SID_MASK;


### PR DESCRIPTION
This PR adds a small compatibility wrapper for DMA coherent handling in audioreach-driver by introducing AR_SET_DMA_COHERENT(dev) in ar_kcompat.h and using it in q6apm_audio_mem_probe(). For kernel >= 7.2.0, it calls dev_set_dma_coherent(dev); for older kernels, it keeps the legacy dev->dma_coherent = true behavior.

The goal is to fix newer-kernel build failures (struct device no longer has direct dma_coherent field access) while preserving compatibility and behavior on older kernels.