### PR TITLE
audioreach-driver: q6apm_audio_pkt: remove q6apm_audio_is_adsp_ready() call from probe

### DIFF
--- a/audioreach-driver/q6apm_audio_pkt.c
+++ b/audioreach-driver/q6apm_audio_pkt.c
@@ -580,7 +580,6 @@ static int q6apm_audio_pkt_probe(gpr_device_t *adev)
 		goto free_dev;
 	}
 
-	q6apm_audio_is_adsp_ready();
 	AUDIO_PKT_INFO("Audio Packet Port Driver Initialized\n");
 	return of_platform_populate(dev->of_node, NULL, NULL, dev);
 


### PR DESCRIPTION
Remove q6apm_audio_is_adsp_ready() call from probe to avoid unwanted wait time.

CRs-Fixed: 4588877